### PR TITLE
LEX namespace restructuring: bracketed segment tag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Legion::Logging Changelog
 
+## v1.2.3
+
+### Changed
+- `Builder#text_format` now accepts `lex_segments:` array and formats it as stacked brackets (e.g. `[agentic][cognitive][anchor]`)
+- Falls back to legacy `lex:` string kwarg for backward compatibility with existing callers
+- `lex: nil` no longer produces a spurious `[]` bracket in log output
+
 ## v1.2.2
 
 ### Added

--- a/lib/legion/logging/builder.rb
+++ b/lib/legion/logging/builder.rb
@@ -33,7 +33,11 @@ module Legion
 
       def text_format(include_pid: false, **options)
         log.formatter = proc do |severity, datetime, _progname, msg|
-          options[:lex_name] = options.key?(:lex) ? "[#{options[:lex]}]" : nil
+          options[:lex_name] = if options.key?(:lex_segments)
+                                 options[:lex_segments].map { |s| "[#{s}]" }.join
+                               elsif options.key?(:lex) && !options[:lex].nil?
+                                 "[#{options[:lex]}]"
+                               end
           unless options[:lex_name].nil?
             loc  = caller_locations[4]
             path = loc.to_s.split('/').last(2)

--- a/lib/legion/logging/version.rb
+++ b/lib/legion/logging/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Logging
-    VERSION = '1.2.2'
+    VERSION = '1.2.3'
   end
 end

--- a/spec/legion/logging/builder_spec.rb
+++ b/spec/legion/logging/builder_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Legion::Logging::Builder do
+  describe '#text_format with lex_segments:' do
+    it 'formats lex_segments as stacked brackets' do
+      logger = Legion::Logging::Logger.new(lex_segments: %w[agentic cognitive anchor])
+      expect { logger.info('hello') }.to output(/\[agentic\]\[cognitive\]\[anchor\]/).to_stdout_from_any_process
+      expect { logger.info('hello') }.to output(/hello/).to_stdout_from_any_process
+    end
+
+    it 'formats single-segment lex_segments as single bracket' do
+      logger = Legion::Logging::Logger.new(lex_segments: %w[node])
+      expect { logger.info('hello') }.to output(/\[node\]/).to_stdout_from_any_process
+    end
+
+    it 'falls back to legacy lex: string when lex_segments not present' do
+      logger = Legion::Logging::Logger.new(lex: 'microsoft_teams')
+      expect { logger.info('hello') }.to output(/\[microsoft_teams\]/).to_stdout_from_any_process
+    end
+
+    it 'produces no lex bracket when neither lex nor lex_segments present' do
+      logger = Legion::Logging::Logger.new
+      # Output should not contain a bracket followed immediately by word chars then more of the message
+      # i.e. no [something] tag in the line (timestamps are [datetime] so we check for lowercase alpha after bracket)
+      expect { logger.info('hello') }.not_to output(/\[[a-z].*?\].*?hello/).to_stdout_from_any_process
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds support for `lex_segments:` array in log formatting, enabling bracketed multi-segment tags like `[agentic][cognitive][anchor]` for nested extensions.

## Changes

- `Legion::Logging::Builder#text_format` now accepts `lex_segments:` array and formats as `[seg][seg]`
- Falls back to legacy `lex:` string for flat extensions (backward compatible)

## Examples

```
# Flat extension (unchanged)
[node] Starting heartbeat...

# Nested agentic extension (new)
[agentic][cognitive][anchor] Processing trace...
[agentic][cognitive][dissonance][resolution] Resolving conflict...
```

## Related PRs

- LegionIO: LEX namespace restructuring (consumes this)