### PR TITLE
v1.4.0-1.4.2: structured exception logging + event categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Legion::Logging Changelog
 
+## [1.4.2] - 2026-03-28
+
+### Added
+- `Legion::Logging::CategoryRegistry` module: extension-defined event category registration with `register_category`, `registered_categories`, `category_registered?`, and `category_info` methods
+- `Legion::Logging.register_category` and `Legion::Logging.registered_categories` delegate methods on the top-level module
+- `category:` keyword argument on `EventBuilder.build` — emits `category` field in structured log events when provided
+- `SIEMExporter.format_for_elk` now includes `category` field when the event hash carries `:category` or `"category"`
+
 ## [1.4.1] - 2026-03-27
 
 ### Fixed

--- a/lib/legion/logging.rb
+++ b/lib/legion/logging.rb
@@ -7,6 +7,7 @@ require 'legion/logging/builder'
 require 'legion/logging/event_builder'
 require 'legion/logging/async_writer'
 require 'legion/logging/helper'
+require 'legion/logging/category_registry'
 
 require 'json'
 require 'logger'
@@ -30,6 +31,14 @@ module Legion
 
       def exception_writer
         @exception_writer || DEFAULT_EXCEPTION_WRITER
+      end
+
+      def register_category(name, description: nil, expected_fields: [])
+        CategoryRegistry.register_category(name, description: description, expected_fields: expected_fields)
+      end
+
+      def registered_categories
+        CategoryRegistry.registered_categories
       end
 
       def setup(level: 'info', format: :text, async: true, **options)

--- a/lib/legion/logging/category_registry.rb
+++ b/lib/legion/logging/category_registry.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Legion
+  module Logging
+    module CategoryRegistry
+      VALID_NAME_PATTERN = /\A[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*\z/
+
+      class << self
+        def register_category(name, description: nil, expected_fields: [])
+          name = name.to_s
+          raise ArgumentError, "invalid category name: #{name.inspect}" unless name.match?(VALID_NAME_PATTERN)
+
+          registry[name] = {
+            name:            name,
+            description:     description,
+            expected_fields: Array(expected_fields)
+          }.freeze
+          name
+        end
+
+        def registered_categories
+          registry.dup.freeze
+        end
+
+        def category_registered?(name)
+          registry.key?(name.to_s)
+        end
+
+        def category_info(name)
+          registry[name.to_s]
+        end
+
+        def clear!
+          registry.clear
+        end
+
+        private
+
+        def registry
+          @registry ||= {}
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/logging/event_builder.rb
+++ b/lib/legion/logging/event_builder.rb
@@ -13,7 +13,7 @@ module Legion
       BACKTRACE_FALLBACK_FRAMES = 20
 
       class << self
-        def build(level:, message:, lex: nil, lex_segments: nil, context: nil, caller_offset: 2)
+        def build(level:, message:, lex: nil, lex_segments: nil, context: nil, category: nil, caller_offset: 2)
           event = base_fields(level, message)
           event[:lex] = derive_lex_source(lex, lex_segments)
           add_node(event)
@@ -21,6 +21,7 @@ module Legion
           add_exception_info(event, message)
           add_gem_info(event, event[:lex])
           event[:context] = context if context
+          event[:category] = category.to_s if category
           event.compact
         end
 

--- a/lib/legion/logging/siem_exporter.rb
+++ b/lib/legion/logging/siem_exporter.rb
@@ -37,12 +37,17 @@ module Legion
         end
 
         def format_for_elk(event, index: 'legion')
-          {
+          result = {
             '@timestamp' => Time.now.utc.iso8601,
             'index'      => index,
             'message'    => redact_phi(event.to_s),
             'source'     => 'legion'
           }
+          if event.is_a?(Hash)
+            category = event[:category] || event['category']
+            result['category'] = category.to_s if category
+          end
+          result
         end
       end
     end

--- a/lib/legion/logging/version.rb
+++ b/lib/legion/logging/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Logging
-    VERSION = '1.4.1'
+    VERSION = '1.4.2'
   end
 end

--- a/spec/legion/logging/category_registry_spec.rb
+++ b/spec/legion/logging/category_registry_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/logging/category_registry'
+
+RSpec.describe Legion::Logging::CategoryRegistry do
+  before { described_class.clear! }
+
+  describe '.register_category' do
+    it 'registers a simple category name' do
+      described_class.register_category('security')
+      expect(described_class.category_registered?('security')).to be true
+    end
+
+    it 'registers a hierarchical dot-separated name' do
+      described_class.register_category('agent.execution')
+      expect(described_class.category_registered?('agent.execution')).to be true
+    end
+
+    it 'registers a deeply nested name' do
+      described_class.register_category('security.finding.critical')
+      expect(described_class.category_registered?('security.finding.critical')).to be true
+    end
+
+    it 'stores description metadata' do
+      described_class.register_category('audit.access', description: 'User access audit events')
+      info = described_class.category_info('audit.access')
+      expect(info[:description]).to eq('User access audit events')
+    end
+
+    it 'stores expected_fields metadata' do
+      described_class.register_category('agent.execution', expected_fields: %w[agent_id duration_ms])
+      info = described_class.category_info('agent.execution')
+      expect(info[:expected_fields]).to eq(%w[agent_id duration_ms])
+    end
+
+    it 'returns the registered name' do
+      result = described_class.register_category('task.complete')
+      expect(result).to eq('task.complete')
+    end
+
+    it 'accepts a symbol name and coerces to string' do
+      described_class.register_category(:'security.finding')
+      expect(described_class.category_registered?('security.finding')).to be true
+    end
+
+    it 'raises ArgumentError for names with uppercase letters' do
+      expect { described_class.register_category('Security') }.to raise_error(ArgumentError, /invalid category name/)
+    end
+
+    it 'raises ArgumentError for names starting with a digit' do
+      expect { described_class.register_category('1security') }.to raise_error(ArgumentError, /invalid category name/)
+    end
+
+    it 'raises ArgumentError for names with spaces' do
+      expect { described_class.register_category('security finding') }.to raise_error(ArgumentError, /invalid category name/)
+    end
+
+    it 'raises ArgumentError for empty name' do
+      expect { described_class.register_category('') }.to raise_error(ArgumentError, /invalid category name/)
+    end
+
+    it 'overwrites an existing registration with new metadata' do
+      described_class.register_category('infra.deploy', description: 'v1')
+      described_class.register_category('infra.deploy', description: 'v2')
+      expect(described_class.category_info('infra.deploy')[:description]).to eq('v2')
+    end
+  end
+
+  describe '.registered_categories' do
+    it 'returns an empty hash when nothing is registered' do
+      expect(described_class.registered_categories).to eq({})
+    end
+
+    it 'returns all registered categories keyed by name' do
+      described_class.register_category('net.connect')
+      described_class.register_category('net.disconnect')
+      categories = described_class.registered_categories
+      expect(categories.keys).to contain_exactly('net.connect', 'net.disconnect')
+    end
+
+    it 'returns a frozen copy that cannot be mutated' do
+      described_class.register_category('sys.boot')
+      copy = described_class.registered_categories
+      expect(copy).to be_frozen
+    end
+
+    it 'returned copy does not share identity with the internal registry' do
+      described_class.register_category('sys.boot')
+      copy = described_class.registered_categories
+      expect(copy).not_to be(described_class.registered_categories.object_id)
+    end
+  end
+
+  describe '.category_registered?' do
+    it 'returns true for a registered category' do
+      described_class.register_category('task.start')
+      expect(described_class.category_registered?('task.start')).to be true
+    end
+
+    it 'returns false for an unknown category' do
+      expect(described_class.category_registered?('does.not.exist')).to be false
+    end
+
+    it 'accepts a symbol argument' do
+      described_class.register_category('task.start')
+      expect(described_class.category_registered?(:'task.start')).to be true
+    end
+  end
+
+  describe '.category_info' do
+    it 'returns the metadata hash for a registered category' do
+      described_class.register_category('audit.login', description: 'Login events', expected_fields: ['user_id'])
+      info = described_class.category_info('audit.login')
+      expect(info[:name]).to eq('audit.login')
+      expect(info[:description]).to eq('Login events')
+      expect(info[:expected_fields]).to eq(['user_id'])
+    end
+
+    it 'returns nil for an unregistered category' do
+      expect(described_class.category_info('ghost')).to be_nil
+    end
+  end
+end

--- a/spec/legion/logging/event_builder_spec.rb
+++ b/spec/legion/logging/event_builder_spec.rb
@@ -103,6 +103,28 @@ RSpec.describe Legion::Logging::EventBuilder do
       event = described_class.build(level: :error, message: "\e[31mred error\e[0m")
       expect(event[:message]).to eq('red error')
     end
+
+    it 'includes category when provided' do
+      event = described_class.build(level: :info, message: 'finding detected', category: 'security.finding')
+      expect(event[:category]).to eq('security.finding')
+    end
+
+    it 'includes category when provided as a symbol' do
+      event = described_class.build(level: :info, message: 'agent done', category: :'agent.execution')
+      expect(event[:category]).to eq('agent.execution')
+    end
+
+    it 'omits category key when category is nil' do
+      event = described_class.build(level: :info, message: 'no category')
+      expect(event).not_to have_key(:category)
+    end
+
+    it 'does not affect other fields when category is present' do
+      event = described_class.build(level: :warn, message: 'check this', category: 'net.connect')
+      expect(event[:level]).to eq(:warn)
+      expect(event[:message]).to eq('check this')
+      expect(event[:category]).to eq('net.connect')
+    end
   end
 
   describe '.build_exception' do

--- a/spec/legion/logging/siem_exporter_spec.rb
+++ b/spec/legion/logging/siem_exporter_spec.rb
@@ -34,5 +34,27 @@ RSpec.describe Legion::Logging::SIEMExporter do
       result = described_class.format_for_elk('test', index: 'custom')
       expect(result['index']).to eq('custom')
     end
+
+    it 'includes category when event hash has symbol key :category' do
+      event = { message: 'security alert', category: 'security.finding' }
+      result = described_class.format_for_elk(event)
+      expect(result['category']).to eq('security.finding')
+    end
+
+    it 'includes category when event hash has string key "category"' do
+      event = { 'message' => 'access granted', 'category' => 'audit.access' }
+      result = described_class.format_for_elk(event)
+      expect(result['category']).to eq('audit.access')
+    end
+
+    it 'omits category key when event hash has no category' do
+      result = described_class.format_for_elk({ message: 'plain event' })
+      expect(result).not_to have_key('category')
+    end
+
+    it 'omits category key when event is a plain string' do
+      result = described_class.format_for_elk('plain string event')
+      expect(result).not_to have_key('category')
+    end
   end
 end

--- a/spec/legion/logging_spec.rb
+++ b/spec/legion/logging_spec.rb
@@ -92,4 +92,31 @@ RSpec.describe Legion::Logging do
     expect { Legion::Logging::Logger.new(level: nil) }.not_to raise_exception
     expect { Legion::Logging::Logger.new(level: 'fewlkjf') }.not_to raise_exception
   end
+
+  describe '.register_category' do
+    before { Legion::Logging::CategoryRegistry.clear! }
+
+    it 'registers a category via the top-level module' do
+      Legion::Logging.register_category('security.finding', description: 'Security findings')
+      expect(Legion::Logging::CategoryRegistry.category_registered?('security.finding')).to be true
+    end
+
+    it 'returns the registered name' do
+      result = Legion::Logging.register_category('agent.execution')
+      expect(result).to eq('agent.execution')
+    end
+  end
+
+  describe '.registered_categories' do
+    before { Legion::Logging::CategoryRegistry.clear! }
+
+    it 'returns an empty hash when nothing is registered' do
+      expect(Legion::Logging.registered_categories).to eq({})
+    end
+
+    it 'returns registered categories after registration' do
+      Legion::Logging.register_category('task.complete')
+      expect(Legion::Logging.registered_categories).to have_key('task.complete')
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Structured exception logging with pluggable writer lambdas (v1.4.0)
- Vault token/JWT/lease redaction patterns (v1.4.1)
- Event category registration mechanism (v1.4.2, closes #5)
- Copilot review fixes

## Test plan
- 256 examples, 0 failures
- 0 rubocop offenses