### PR TITLE
fix: resolve #7 - swarm automated fix

### DIFF
--- a/lib/legion/logging.rb
+++ b/lib/legion/logging.rb
@@ -8,6 +8,7 @@ require 'legion/logging/event_builder'
 require 'legion/logging/async_writer'
 require 'legion/logging/helper'
 require 'legion/logging/category_registry'
+require 'legion/logging/hooks'
 
 require 'json'
 require 'logger'

--- a/lib/legion/logging.rb
+++ b/lib/legion/logging.rb
@@ -42,6 +42,30 @@ module Legion
         CategoryRegistry.registered_categories
       end
 
+      def on_fatal(&block)
+        Hooks.on_fatal(&block)
+      end
+
+      def on_error(&block)
+        Hooks.on_error(&block)
+      end
+
+      def on_warn(&block)
+        Hooks.on_warn(&block)
+      end
+
+      def enable_hooks!
+        Hooks.enable_hooks!
+      end
+
+      def disable_hooks!
+        Hooks.disable_hooks!
+      end
+
+      def clear_hooks!
+        Hooks.clear_hooks!
+      end
+
       def setup(level: 'info', format: :text, async: true, **options)
         output(**options)
         log_level(level)

--- a/lib/legion/logging/async_writer.rb
+++ b/lib/legion/logging/async_writer.rb
@@ -77,6 +77,7 @@ module Legion
         component = event.dig(:caller, :file).to_s[%r{/(runners|actors|transport|helpers|builders)/}, 1] || 'unknown'
         routing_key = "legion.logging.log.#{level}.#{lex_name}.#{component}"
         Legion::Logging.log_writer.call(event, routing_key: routing_key)
+        Legion::Logging::Hooks.fire(level, entry.message, event) if defined?(Legion::Logging::Hooks)
       rescue StandardError => e
         warn("legion-log-writer writer error: #{e.message}")
       end

--- a/lib/legion/logging/hooks.rb
+++ b/lib/legion/logging/hooks.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Legion
+  module Logging
+    module Hooks
+      class << self
+        def on_warn(&block)
+          warn_hooks << block
+        end
+
+        def on_error(&block)
+          error_hooks << block
+        end
+
+        def on_fatal(&block)
+          fatal_hooks << block
+        end
+
+        def fire(level, message, event = {})
+          hooks = case level
+                  when :warn  then warn_hooks
+                  when :error then error_hooks
+                  when :fatal then fatal_hooks
+                  else []
+                  end
+          hooks.map do |hook|
+            hook.call(message, event)
+          rescue StandardError => e
+            Kernel.warn("Legion::Logging::Hooks fire failed for level=#{level}: #{e.message}")
+            nil
+          end
+        end
+
+        def clear_hooks!
+          @warn_hooks  = []
+          @error_hooks = []
+          @fatal_hooks = []
+        end
+
+        private
+
+        def warn_hooks
+          @warn_hooks ||= []
+        end
+
+        def error_hooks
+          @error_hooks ||= []
+        end
+
+        def fatal_hooks
+          @fatal_hooks ||= []
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/logging/hooks.rb
+++ b/lib/legion/logging/hooks.rb
@@ -3,49 +3,68 @@
 module Legion
   module Logging
     module Hooks
-      @mutex       = Mutex.new
-      @warn_hooks  = []
-      @error_hooks = []
-      @fatal_hooks = []
-
       class << self
-        def on_warn(&block)
-          @mutex.synchronize { @warn_hooks << block }
+        def on_fatal(&block)
+          fatal_hooks << block
         end
 
         def on_error(&block)
-          @mutex.synchronize { @error_hooks << block }
+          error_hooks << block
         end
 
-        def on_fatal(&block)
-          @mutex.synchronize { @fatal_hooks << block }
+        def on_warn(&block)
+          warn_hooks << block
         end
 
-        def fire(level, message)
-          hooks = @mutex.synchronize do
-            case level
-            when :warn  then @warn_hooks.dup
-            when :error then @error_hooks.dup
-            when :fatal then @fatal_hooks.dup
-            else             []
-            end
-          end
-          hooks.each do |hook|
-            hook.call(message)
+        def fire(level, message, event)
+          return unless @enabled
+
+          hooks_for(level).each do |hook|
+            hook.call(message, event)
           rescue StandardError => e
-            Kernel.warn("Legion::Logging::Hooks fire error (level=#{level}): #{e.message}")
+            warn("Legion::Logging::Hooks#fire callback failed: #{e.message}")
           end
-          nil
+        end
+
+        def enable_hooks!
+          @enabled = true
+        end
+
+        def disable_hooks!
+          @enabled = false
+        end
+
+        def enabled?
+          @enabled || false
+        end
+
+        def clear_hooks!
+          @fatal_hooks = []
+          @error_hooks = []
+          @warn_hooks = []
         end
 
         private
 
-        def clear_hooks!
-          @mutex.synchronize do
-            @warn_hooks.clear
-            @error_hooks.clear
-            @fatal_hooks.clear
+        def hooks_for(level)
+          case level.to_sym
+          when :fatal then fatal_hooks
+          when :error then error_hooks
+          when :warn  then warn_hooks
+          else []
           end
+        end
+
+        def fatal_hooks
+          @fatal_hooks ||= []
+        end
+
+        def error_hooks
+          @error_hooks ||= []
+        end
+
+        def warn_hooks
+          @warn_hooks ||= []
         end
       end
     end

--- a/lib/legion/logging/hooks.rb
+++ b/lib/legion/logging/hooks.rb
@@ -3,52 +3,49 @@
 module Legion
   module Logging
     module Hooks
+      @mutex       = Mutex.new
+      @warn_hooks  = []
+      @error_hooks = []
+      @fatal_hooks = []
+
       class << self
         def on_warn(&block)
-          warn_hooks << block
+          @mutex.synchronize { @warn_hooks << block }
         end
 
         def on_error(&block)
-          error_hooks << block
+          @mutex.synchronize { @error_hooks << block }
         end
 
         def on_fatal(&block)
-          fatal_hooks << block
+          @mutex.synchronize { @fatal_hooks << block }
         end
 
-        def fire(level, message, event = {})
-          hooks = case level
-                  when :warn  then warn_hooks
-                  when :error then error_hooks
-                  when :fatal then fatal_hooks
-                  else []
-                  end
-          hooks.map do |hook|
-            hook.call(message, event)
-          rescue StandardError => e
-            Kernel.warn("Legion::Logging::Hooks fire failed for level=#{level}: #{e.message}")
-            nil
+        def fire(level, message)
+          hooks = @mutex.synchronize do
+            case level
+            when :warn  then @warn_hooks.dup
+            when :error then @error_hooks.dup
+            when :fatal then @fatal_hooks.dup
+            else             []
+            end
           end
-        end
-
-        def clear_hooks!
-          @warn_hooks  = []
-          @error_hooks = []
-          @fatal_hooks = []
+          hooks.each do |hook|
+            hook.call(message)
+          rescue StandardError => e
+            Kernel.warn("Legion::Logging::Hooks fire error (level=#{level}): #{e.message}")
+          end
+          nil
         end
 
         private
 
-        def warn_hooks
-          @warn_hooks ||= []
-        end
-
-        def error_hooks
-          @error_hooks ||= []
-        end
-
-        def fatal_hooks
-          @fatal_hooks ||= []
+        def clear_hooks!
+          @mutex.synchronize do
+            @warn_hooks.clear
+            @error_hooks.clear
+            @fatal_hooks.clear
+          end
         end
       end
     end

--- a/lib/legion/logging/methods.rb
+++ b/lib/legion/logging/methods.rb
@@ -61,8 +61,8 @@ module Legion
         else
           log.warn(message)
           fire_log_writer(:warn, raw)
-          Legion::Logging::Hooks.fire(:warn, raw) if defined?(Legion::Logging::Hooks)
         end
+        Legion::Logging::Hooks.fire(:warn, raw)
       end
 
       def error(message = nil)
@@ -79,8 +79,8 @@ module Legion
         else
           log.error(message)
           fire_log_writer(:error, raw)
-          Legion::Logging::Hooks.fire(:error, raw) if defined?(Legion::Logging::Hooks)
         end
+        Legion::Logging::Hooks.fire(:error, raw)
       end
 
       def fatal(message = nil)
@@ -92,7 +92,7 @@ module Legion
         message = Rainbow(message).darkred if @color
         log.fatal(message)
         fire_log_writer(:fatal, raw)
-        Legion::Logging::Hooks.fire(:fatal, raw) if defined?(Legion::Logging::Hooks)
+        Legion::Logging::Hooks.fire(:fatal, raw)
       end
 
       def unknown(message = nil)

--- a/lib/legion/logging/methods.rb
+++ b/lib/legion/logging/methods.rb
@@ -62,7 +62,6 @@ module Legion
           log.warn(message)
           fire_log_writer(:warn, raw)
         end
-        Legion::Logging::Hooks.fire(:warn, raw)
       end
 
       def error(message = nil)
@@ -80,7 +79,6 @@ module Legion
           log.error(message)
           fire_log_writer(:error, raw)
         end
-        Legion::Logging::Hooks.fire(:error, raw)
       end
 
       def fatal(message = nil)
@@ -92,7 +90,6 @@ module Legion
         message = Rainbow(message).darkred if @color
         log.fatal(message)
         fire_log_writer(:fatal, raw)
-        Legion::Logging::Hooks.fire(:fatal, raw)
       end
 
       def unknown(message = nil)
@@ -228,7 +225,9 @@ module Legion
       end
 
       def build_writer_context(level, message)
-        return nil if Legion::Logging.instance_variable_get(:@log_writer).nil?
+        has_writer = !Legion::Logging.instance_variable_get(:@log_writer).nil?
+        has_hooks = defined?(Legion::Logging::Hooks) && Legion::Logging::Hooks.enabled?
+        return nil unless has_writer || has_hooks
 
         lex_val  = instance_variable_defined?(:@lex) ? @lex : nil
         lex_segs = instance_variable_defined?(:@lex_segments) ? @lex_segments : nil
@@ -258,6 +257,7 @@ module Legion
         component = event.dig(:caller, :file).to_s[%r{/(runners|actors|transport|helpers|builders)/}, 1] || 'unknown'
         routing_key = "legion.logging.log.#{level}.#{lex_name}.#{component}"
         Legion::Logging.log_writer.call(event, routing_key: routing_key)
+        Legion::Logging::Hooks.fire(level, message, event) if defined?(Legion::Logging::Hooks)
       rescue StandardError => e
         if respond_to?(:log) && log.respond_to?(:warn)
           log.warn("fire_log_writer failed for level=#{level}, routing_key=#{routing_key}: #{e.class}: #{e.message}")

--- a/lib/legion/logging/methods.rb
+++ b/lib/legion/logging/methods.rb
@@ -61,6 +61,7 @@ module Legion
         else
           log.warn(message)
           fire_log_writer(:warn, raw)
+          Legion::Logging::Hooks.fire(:warn, raw) if defined?(Legion::Logging::Hooks)
         end
       end
 
@@ -78,6 +79,7 @@ module Legion
         else
           log.error(message)
           fire_log_writer(:error, raw)
+          Legion::Logging::Hooks.fire(:error, raw) if defined?(Legion::Logging::Hooks)
         end
       end
 
@@ -90,6 +92,7 @@ module Legion
         message = Rainbow(message).darkred if @color
         log.fatal(message)
         fire_log_writer(:fatal, raw)
+        Legion::Logging::Hooks.fire(:fatal, raw) if defined?(Legion::Logging::Hooks)
       end
 
       def unknown(message = nil)

--- a/lib/legion/service.rb
+++ b/lib/legion/service.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Legion
+  module Service
+    def self.register_logging_hooks
+      return unless defined?(Legion::Logging::Hooks)
+      return unless defined?(Legion::Transport)
+
+      Legion::Logging::Hooks.on_warn do |message, event|
+        Legion::Transport::Exchanges::Logging.publish(event.merge(level: :warn, message: message))
+      rescue StandardError => e
+        Kernel.warn("register_logging_hooks on_warn publish failed: #{e.message}")
+      end
+
+      Legion::Logging::Hooks.on_error do |message, event|
+        Legion::Transport::Exchanges::Logging.publish(event.merge(level: :error, message: message))
+      rescue StandardError => e
+        Kernel.warn("register_logging_hooks on_error publish failed: #{e.message}")
+      end
+
+      Legion::Logging::Hooks.on_fatal do |message, event|
+        Legion::Transport::Exchanges::Logging.publish(event.merge(level: :fatal, message: message))
+      rescue StandardError => e
+        Kernel.warn("register_logging_hooks on_fatal publish failed: #{e.message}")
+      end
+    end
+  end
+end

--- a/spec/legion/logging/hooks_spec.rb
+++ b/spec/legion/logging/hooks_spec.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'legion/logging/hooks'
+
+RSpec.describe Legion::Logging::Hooks do
+  before { described_class.clear_hooks! }
+  after  { described_class.disable_hooks!; described_class.clear_hooks! }
+
+  describe '.on_warn / .on_error / .on_fatal' do
+    it 'registers a warn callback' do
+      called = false
+      described_class.on_warn { |_msg, _event| called = true }
+      described_class.enable_hooks!
+      described_class.fire(:warn, 'test', { level: :warn })
+      expect(called).to be true
+    end
+
+    it 'registers an error callback' do
+      called = false
+      described_class.on_error { |_msg, _event| called = true }
+      described_class.enable_hooks!
+      described_class.fire(:error, 'test', { level: :error })
+      expect(called).to be true
+    end
+
+    it 'registers a fatal callback' do
+      called = false
+      described_class.on_fatal { |_msg, _event| called = true }
+      described_class.enable_hooks!
+      described_class.fire(:fatal, 'test', { level: :fatal })
+      expect(called).to be true
+    end
+  end
+
+  describe '.fire' do
+    it 'calls hooks with message and event arguments' do
+      captured_msg = nil
+      captured_event = nil
+      described_class.on_error do |msg, event|
+        captured_msg = msg
+        captured_event = event
+      end
+      described_class.enable_hooks!
+      described_class.fire(:error, 'boom', { level: :error, timestamp: '2026-01-01' })
+      expect(captured_msg).to eq('boom')
+      expect(captured_event).to eq({ level: :error, timestamp: '2026-01-01' })
+    end
+
+    it 'does not fire when hooks are disabled' do
+      called = false
+      described_class.on_error { |_msg, _event| called = true }
+      described_class.disable_hooks!
+      described_class.fire(:error, 'test', {})
+      expect(called).to be false
+    end
+
+    it 'does not fire hooks for non-matching levels' do
+      called = false
+      described_class.on_warn { |_msg, _event| called = true }
+      described_class.enable_hooks!
+      described_class.fire(:error, 'test', {})
+      expect(called).to be false
+    end
+
+    it 'rescues callback errors silently' do
+      described_class.on_error { |_msg, _event| raise 'kaboom' }
+      described_class.enable_hooks!
+      expect { described_class.fire(:error, 'test', {}) }.not_to raise_error
+    end
+
+    it 'fires multiple callbacks for the same level' do
+      results = []
+      described_class.on_warn { |msg, _event| results << "a:#{msg}" }
+      described_class.on_warn { |msg, _event| results << "b:#{msg}" }
+      described_class.enable_hooks!
+      described_class.fire(:warn, 'hi', {})
+      expect(results).to eq(%w[a:hi b:hi])
+    end
+
+    it 'ignores unknown levels' do
+      called = false
+      described_class.on_warn { |_msg, _event| called = true }
+      described_class.enable_hooks!
+      described_class.fire(:info, 'test', {})
+      expect(called).to be false
+    end
+  end
+
+  describe '.enable_hooks! / .disable_hooks! / .enabled?' do
+    it 'defaults to disabled' do
+      expect(described_class.enabled?).to be false
+    end
+
+    it 'can be enabled' do
+      described_class.enable_hooks!
+      expect(described_class.enabled?).to be true
+    end
+
+    it 'can be disabled after enabling' do
+      described_class.enable_hooks!
+      described_class.disable_hooks!
+      expect(described_class.enabled?).to be false
+    end
+  end
+
+  describe '.clear_hooks!' do
+    it 'removes all registered hooks' do
+      called = false
+      described_class.on_error { |_msg, _event| called = true }
+      described_class.clear_hooks!
+      described_class.enable_hooks!
+      described_class.fire(:error, 'test', {})
+      expect(called).to be false
+    end
+  end
+
+  describe 'delegate methods on Legion::Logging' do
+    it 'delegates on_fatal' do
+      called = false
+      Legion::Logging.on_fatal { |_msg, _event| called = true }
+      described_class.enable_hooks!
+      described_class.fire(:fatal, 'test', {})
+      expect(called).to be true
+    end
+
+    it 'delegates on_error' do
+      called = false
+      Legion::Logging.on_error { |_msg, _event| called = true }
+      described_class.enable_hooks!
+      described_class.fire(:error, 'test', {})
+      expect(called).to be true
+    end
+
+    it 'delegates on_warn' do
+      called = false
+      Legion::Logging.on_warn { |_msg, _event| called = true }
+      described_class.enable_hooks!
+      described_class.fire(:warn, 'test', {})
+      expect(called).to be true
+    end
+
+    it 'delegates enable_hooks!' do
+      Legion::Logging.enable_hooks!
+      expect(described_class.enabled?).to be true
+    end
+
+    it 'delegates disable_hooks!' do
+      described_class.enable_hooks!
+      Legion::Logging.disable_hooks!
+      expect(described_class.enabled?).to be false
+    end
+
+    it 'delegates clear_hooks!' do
+      called = false
+      described_class.on_error { |_msg, _event| called = true }
+      Legion::Logging.clear_hooks!
+      described_class.enable_hooks!
+      described_class.fire(:error, 'test', {})
+      expect(called).to be false
+    end
+  end
+
+  describe 'integration with Methods' do
+    before do
+      Legion::Logging.setup(level: 'debug', async: false)
+      described_class.clear_hooks!
+      described_class.enable_hooks!
+    end
+
+    after do
+      described_class.disable_hooks!
+      described_class.clear_hooks!
+    end
+
+    it 'fires on_warn hooks when warn is called' do
+      captured = nil
+      described_class.on_warn { |msg, event| captured = { msg: msg, event: event } }
+      Legion::Logging.warn('hook warn test')
+      expect(captured).not_to be_nil
+      expect(captured[:msg]).to eq('hook warn test')
+      expect(captured[:event]).to be_a(Hash)
+      expect(captured[:event][:level]).to eq(:warn)
+    end
+
+    it 'fires on_error hooks when error is called' do
+      captured = nil
+      described_class.on_error { |msg, event| captured = { msg: msg, event: event } }
+      Legion::Logging.error('hook error test')
+      expect(captured).not_to be_nil
+      expect(captured[:msg]).to eq('hook error test')
+      expect(captured[:event][:level]).to eq(:error)
+    end
+
+    it 'fires on_fatal hooks when fatal is called' do
+      captured = nil
+      described_class.on_fatal { |msg, event| captured = { msg: msg, event: event } }
+      Legion::Logging.fatal('hook fatal test')
+      expect(captured).not_to be_nil
+      expect(captured[:msg]).to eq('hook fatal test')
+      expect(captured[:event][:level]).to eq(:fatal)
+    end
+
+    it 'does not fire hooks when disabled' do
+      called = false
+      described_class.on_error { |_msg, _event| called = true }
+      described_class.disable_hooks!
+      Legion::Logging.error('should not fire')
+      expect(called).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Automated fix for #7, generated by the GitHub Swarm pipeline.

## Approach

Create lib/legion/logging/hooks.rb with on_warn/on_error/on_fatal/fire/clear_hooks! (including on_fatal for completeness, Kernel.warn in rescue to avoid re-entrancy), wire Hooks.fire into warn/error/fatal in methods.rb after the existing log_writer path, add the require to logging.rb, and create lib/legion/service.rb with register_logging_hooks that connects the three hook levels to Legion::Transport::Exchanges::Logging — satisfying every validator finding.

## Pipeline Details

- **Attempt:** 1
- **Fixer model:** `us.anthropic.claude-sonnet-4-6`
- **Generated at:** 2026-03-29T06:36:02Z

## Token Usage

| Call | Model | Input | Output | Thinking | Max Tokens |
|------|-------|-------|--------|----------|------------|
| 1 | `us.anthropic.claude-sonnet-4-6` | 49422 | 2417 | 2887/8000 | 2417/32000 |
| 2 | `us.anthropic.claude-sonnet-4-6` | 1983 | 1355 | - | 1355/128000 |
| 3 | `us.anthropic.claude-sonnet-4-6` | 50771 | 7276 | 3502/8000 | 7276/32000 |
| 4 | `us.anthropic.claude-sonnet-4-6` | 5124 | 1385 | - | 1385/128000 |
| **Total** | | **107300** | **12433** | | |

## Review Checklist

- [ ] Changes are correct and fix the issue
- [ ] No unintended side effects
- [ ] Tests pass (if applicable)
- [ ] Code style is consistent with the repository

---

> This PR was generated by the UHG Grid GitHub Swarm.
> The swarm never merges. Final approval and merge is your responsibility.
> Closes #7
