### PR TITLE
refactor logging helper: shared output, segment tagging, exception handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,31 @@ on:
   push:
     branches: [main]
   pull_request:
+  schedule:
+    - cron: '0 9 * * 1'
 
 jobs:
   ci:
     uses: LegionIO/.github/.github/workflows/ci.yml@main
 
+  lint:
+    uses: LegionIO/.github/.github/workflows/lint-patterns.yml@main
+
+  security:
+    uses: LegionIO/.github/.github/workflows/security-scan.yml@main
+
+  version-changelog:
+    uses: LegionIO/.github/.github/workflows/version-changelog.yml@main
+
+  dependency-review:
+    uses: LegionIO/.github/.github/workflows/dependency-review.yml@main
+
+  stale:
+    if: github.event_name == 'schedule'
+    uses: LegionIO/.github/.github/workflows/stale.yml@main
+
   release:
-    needs: ci
+    needs: [ci, lint]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: LegionIO/.github/.github/workflows/release.yml@main
     secrets:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Legion::Logging Changelog
 
+## [1.4.3] - 2026-04-01
+
+### Added
+- `TaggedLogger` lightweight proxy: delegates to singleton for shared stdout/file/async output
+- `Helper#derive_log_segments` with class-level `SEGMENT_CACHE` — auto-derives `[llm][router]` from namespace
+- `Helper#with_log_context` for block-scoped method name thread-locals (`{dispatch}` in log output)
+- `Helper#handle_exception` with direct EventBuilder calls, per-line Rainbow coloring, structured AMQP publish
+- `Helper.current_log_method`, `.current_log_segments`, `.current_context` thread-local readers
+- `Legion::Logging::Settings` module with logger defaults
+- `COMPONENT_MAP` with 18 component types (runners, actors, hooks, absorbers, tools, adapters, middleware, etc.)
+- `EXCEPTION_COLORS` map for per-level exception coloring (bold first line, faint backtrace)
+- `Thread.current[:legion_context]` support for wire protocol fields (task_id, conversation_id, chain_id)
+- Redaction applied to exception stdout output when redaction is enabled
+- Method context (`legion_log_method`) included in structured exception events
+- `AsyncWriter::LogEntry` carries `segments` and `method_ctx` for thread-local propagation to writer thread
+- `Builder#resolve_lex_tag` and `#build_runner_trace` extracted from `text_format`
+
+### Changed
+- `Helper#log` returns `TaggedLogger` instead of `Logger.new` (shared output, one async thread)
+- `Helper#log_name`/`gem_name`/`gem_spec` replace `log_lex_name`/`lex_gem_name`/`gem_spec_for_lex` with multi-prefix resolution
+- `gem_name` and `gem_spec` memoized per instance
+- `COMPONENT_REGEX` in Methods expanded from 5 to 18 component types
+- `build_writer_context` reads `Thread.current[:legion_log_segments]` instead of stale `@lex_segments` ivar
+- `Builder#output` delegates to `set_log` (was parallel implementation)
+- `Builder#caller_locations` allocates single frame instead of full stack
+- Unknown log level strings default to INFO instead of DEBUG
+- `EventBuilder#legion_versions` and `#resolve_gem_spec` memoized
+- `EXCEPTION_PRIORITY` extracted to frozen constant in Methods (was inline hash allocation per call)
+- `text_format` and `json_format` in Builder read thread-locals for segments and method context
+
+### Fixed
+- `fire_log_writer` rescue no longer references undefined `routing_key` variable
+- Splunk auth header in `http_transport` — `apply_auth` receives actual URI instead of always evaluating against `URI('/')`
+- `TaggedLogger#initialize` accepts `**_opts` splat for unexpected settings keys
+- `TaggedLogger#trace` guards nil `size` to prevent `TypeError` on `caller_locations`
+
+### Removed
+- `TaggedLogger#runner_exception` (runner business logic, not logging concern)
+- `TaggedLogger#log_exception` (use `Helper#handle_exception` instead)
+- `Builder#log_level` no-op `@log = log` self-assignment
+
 ## [1.4.2] - 2026-03-28
 
 ### Added

--- a/lib/legion/logging.rb
+++ b/lib/legion/logging.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require 'legion/logging/version'
+require 'legion/logging/settings'
 require 'legion/logging/logger'
 require 'legion/logging/methods'
 require 'legion/logging/builder'
 require 'legion/logging/event_builder'
 require 'legion/logging/async_writer'
+require 'legion/logging/tagged_logger'
 require 'legion/logging/helper'
 require 'legion/logging/category_registry'
 require 'legion/logging/hooks'
@@ -23,7 +25,7 @@ module Legion
       attr_reader :color
       attr_writer :log_writer, :exception_writer
 
-      DEFAULT_LOG_WRITER       = ->(_event, routing_key:) {}
+      DEFAULT_LOG_WRITER = ->(_event, routing_key:) {}
       DEFAULT_EXCEPTION_WRITER = ->(_event, routing_key:, headers:, properties:) {}
 
       def log_writer

--- a/lib/legion/logging/async_writer.rb
+++ b/lib/legion/logging/async_writer.rb
@@ -3,7 +3,7 @@
 module Legion
   module Logging
     class AsyncWriter
-      LogEntry = ::Data.define(:level, :message, :writer_context)
+      LogEntry = ::Data.define(:level, :message, :writer_context, :segments, :method_ctx)
       SHUTDOWN = :shutdown
 
       def initialize(logger, buffer_size: 10_000)
@@ -54,10 +54,17 @@ module Legion
       end
 
       def write_entry(entry)
+        prev_segments   = Thread.current[:legion_log_segments]
+        prev_method_ctx = Thread.current[:legion_log_method]
+        Thread.current[:legion_log_segments] = entry.segments   if entry.segments
+        Thread.current[:legion_log_method]   = entry.method_ctx if entry.method_ctx
         @logger.send(entry.level, entry.message)
         fire_writer(entry) if entry.writer_context
       rescue StandardError => e
         warn("legion-log-writer error: #{e.message} (#{e.backtrace&.first})")
+      ensure
+        Thread.current[:legion_log_segments] = prev_segments
+        Thread.current[:legion_log_method]   = prev_method_ctx
       end
 
       def drain

--- a/lib/legion/logging/async_writer.rb
+++ b/lib/legion/logging/async_writer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'methods'
+
 module Legion
   module Logging
     class AsyncWriter

--- a/lib/legion/logging/async_writer.rb
+++ b/lib/legion/logging/async_writer.rb
@@ -74,7 +74,7 @@ module Legion
         event = ctx[:event]
         level = ctx[:level]
         lex_name = event[:lex] || 'core'
-        component = event.dig(:caller, :file).to_s[%r{/(runners|actors|transport|helpers|builders)/}, 1] || 'unknown'
+        component = event.dig(:caller, :file).to_s[Legion::Logging::Methods::COMPONENT_REGEX, 1] || 'unknown'
         routing_key = "legion.logging.log.#{level}.#{lex_name}.#{component}"
         Legion::Logging.log_writer.call(event, routing_key: routing_key)
         Legion::Logging::Hooks.fire(level, entry.message, event) if defined?(Legion::Logging::Hooks)

--- a/lib/legion/logging/async_writer.rb
+++ b/lib/legion/logging/async_writer.rb
@@ -58,8 +58,8 @@ module Legion
       def write_entry(entry)
         prev_segments   = Thread.current[:legion_log_segments]
         prev_method_ctx = Thread.current[:legion_log_method]
-        Thread.current[:legion_log_segments] = entry.segments   if entry.segments
-        Thread.current[:legion_log_method]   = entry.method_ctx if entry.method_ctx
+        Thread.current[:legion_log_segments] = entry.segments
+        Thread.current[:legion_log_method]   = entry.method_ctx
         @logger.send(entry.level, entry.message)
         fire_writer(entry) if entry.writer_context
       rescue StandardError => e

--- a/lib/legion/logging/builder.rb
+++ b/lib/legion/logging/builder.rb
@@ -27,6 +27,10 @@ module Legion
             thread:    Thread.current.object_id
           }
           entry[:pid] = ::Process.pid if include_pid
+          segments = Thread.current[:legion_log_segments]
+          entry[:segments] = segments if segments
+          method_ctx = Thread.current[:legion_log_method]
+          entry[:method] = method_ctx if method_ctx
           "#{::JSON.generate(entry)}\n"
         rescue StandardError => e
           warn("Legion::Logging::Builder#json_format formatter failed: #{e.message}")
@@ -36,24 +40,12 @@ module Legion
 
       def text_format(include_pid: false, **options)
         log.formatter = proc do |severity, datetime, _progname, msg|
-          options[:lex_name] = if options.key?(:lex_segments)
-                                 options[:lex_segments].map { |s| "[#{s}]" }.join
-                               elsif options.key?(:lex) && !options[:lex].nil?
-                                 "[#{options[:lex]}]"
-                               end
-          unless options[:lex_name].nil?
-            loc  = caller_locations[4]
-            path = loc.to_s.split('/').last(2)
-            runner_trace = {
-              type:        path[0],
-              file:        File.basename(loc.path, '.*'),
-              function:    loc.base_label,
-              line_number: loc.lineno
-            }
-          end
+          lex_name = resolve_lex_tag(options)
+          runner_trace = build_runner_trace if lex_name
+
           string = "[#{datetime}]"
           string.concat("[#{::Process.pid}]") if include_pid
-          string.concat(options[:lex_name]) unless options[:lex_name].nil?
+          string.concat(lex_name) if lex_name
           if runner_trace.is_a?(Hash) && (options[:extended] || severity == 'debug')
             string.concat("[#{runner_trace[:type]}:#{runner_trace[:file]}:#{runner_trace[:function]}:#{runner_trace[:line_number]}]")
           end
@@ -62,17 +54,36 @@ module Legion
         end
       end
 
+      def resolve_lex_tag(options)
+        segments = Thread.current[:legion_log_segments]
+        tag = if segments
+                segments.map { |s| "[#{s}]" }.join
+              elsif options.key?(:lex_segments)
+                options[:lex_segments].map { |s| "[#{s}]" }.join
+              elsif options.key?(:lex) && !options[:lex].nil?
+                "[#{options[:lex]}]"
+              end
+
+        method_ctx = Thread.current[:legion_log_method]
+        tag = "#{tag}{#{method_ctx}}" if tag && method_ctx
+        tag
+      end
+
+      def build_runner_trace
+        loc = caller_locations(6, 1)&.first
+        return unless loc
+
+        path = loc.to_s.split('/').last(2)
+        {
+          type:        path[0],
+          file:        File.basename(loc.path, '.*'),
+          function:    loc.base_label,
+          line_number: loc.lineno
+        }
+      end
+
       def output(**options)
-        if options[:log_file] && options[:log_stdout] != false
-          path = prepare_log_path(options[:log_file])
-          require_relative 'multi_io'
-          io = MultiIO.new($stdout, File.open(path, 'a'))
-          @log = ::Logger.new(io)
-        elsif options[:log_file]
-          @log = ::Logger.new(prepare_log_path(options[:log_file]))
-        else
-          @log = ::Logger.new($stdout)
-        end
+        set_log(logfile: options[:log_file], log_stdout: options[:log_stdout])
       end
 
       def log
@@ -120,10 +131,9 @@ module Legion
                       if level.is_a? Integer
                         level
                       else
-                        0
+                        1
                       end
                     end
-        @log = log
       end
 
       def async?

--- a/lib/legion/logging/event_builder.rb
+++ b/lib/legion/logging/event_builder.rb
@@ -187,12 +187,16 @@ module Legion
         end
 
         def resolve_gem_spec(name)
+          return @gem_spec_cache[name] if defined?(@gem_spec_cache) && @gem_spec_cache.key?(name)
+
+          @gem_spec_cache ||= {}
           [name, "lex-#{name}", "legion-#{name}"].each do |candidate|
-            return Gem::Specification.find_by_name(candidate)
+            spec = Gem::Specification.find_by_name(candidate)
+            return @gem_spec_cache[name] = spec
           rescue Gem::MissingSpecError
             next
           end
-          nil
+          @gem_spec_cache[name] = nil
         end
 
         def strip_ansi(str)
@@ -254,9 +258,13 @@ module Legion
         end
 
         def legion_versions
-          Gem::Specification
-            .select { |s| s.name.start_with?('legion-', 'lex-') }
-            .to_h { |s| [s.name, s.version.to_s] }
+          @legion_versions ||= Gem::Specification
+                               .select { |s| s.name.start_with?('legion-', 'lex-') }
+                               .to_h do |s|
+            [s.name,
+             s.version.to_s]
+          end
+                                                                                        .freeze
         end
 
         def truncate_bytes(str, max)

--- a/lib/legion/logging/event_builder.rb
+++ b/lib/legion/logging/event_builder.rb
@@ -264,7 +264,7 @@ module Legion
             [s.name,
              s.version.to_s]
           end
-                                                                                        .freeze
+                               .freeze
         end
 
         def truncate_bytes(str, max)

--- a/lib/legion/logging/event_builder.rb
+++ b/lib/legion/logging/event_builder.rb
@@ -201,7 +201,7 @@ module Legion
             next
           end
 
-          GEM_SPEC_CACHE_MUTEX.synchronize { cache[name] ||= spec }
+          GEM_SPEC_CACHE_MUTEX.synchronize { cache[name] = spec }
         end
 
         def strip_ansi(str)

--- a/lib/legion/logging/event_builder.rb
+++ b/lib/legion/logging/event_builder.rb
@@ -194,7 +194,7 @@ module Legion
           return cache[name] if cache.key?(name)
 
           spec = nil
-          [name, "lex-#{name}", "legion-#{name}"].each do |candidate|
+          ["lex-#{name}", "legion-#{name}", name].each do |candidate|
             spec = Gem::Specification.find_by_name(candidate)
             break
           rescue Gem::MissingSpecError

--- a/lib/legion/logging/event_builder.rb
+++ b/lib/legion/logging/event_builder.rb
@@ -12,6 +12,9 @@ module Legion
       MAX_TOTAL_BYTES          = 65_536
       BACKTRACE_FALLBACK_FRAMES = 20
 
+      GEM_SPEC_CACHE_MUTEX = Mutex.new
+      private_constant :GEM_SPEC_CACHE_MUTEX
+
       class << self
         def build(level:, message:, lex: nil, lex_segments: nil, context: nil, category: nil, caller_offset: 2)
           event = base_fields(level, message)
@@ -187,16 +190,18 @@ module Legion
         end
 
         def resolve_gem_spec(name)
-          return @gem_spec_cache[name] if defined?(@gem_spec_cache) && @gem_spec_cache.key?(name)
+          cache = (@gem_spec_cache ||= {})
+          return cache[name] if cache.key?(name)
 
-          @gem_spec_cache ||= {}
+          spec = nil
           [name, "lex-#{name}", "legion-#{name}"].each do |candidate|
             spec = Gem::Specification.find_by_name(candidate)
-            return @gem_spec_cache[name] = spec
+            break
           rescue Gem::MissingSpecError
             next
           end
-          @gem_spec_cache[name] = nil
+
+          GEM_SPEC_CACHE_MUTEX.synchronize { cache[name] ||= spec }
         end
 
         def strip_ansi(str)

--- a/lib/legion/logging/helper.rb
+++ b/lib/legion/logging/helper.rb
@@ -1,47 +1,282 @@
 # frozen_string_literal: true
 
+require 'securerandom'
+require_relative 'tagged_logger'
+
 module Legion
   module Logging
     module Helper
+      SEGMENT_CACHE = {} # rubocop:disable Style/MutableConstant
+      COMPONENT_MAP = {
+        'runners'    => :runner,
+        'actors'     => :actor,
+        'actor'      => :actor,
+        'helpers'    => :helper,
+        'hooks'      => :hook,
+        'absorbers'  => :absorber,
+        'matchers'   => :matcher,
+        'transport'  => :transport,
+        'exchanges'  => :exchange,
+        'queues'     => :queue,
+        'messages'   => :message,
+        'data'       => :data,
+        'builders'   => :builder,
+        'tools'      => :tool,
+        'adapters'   => :adapter,
+        'engines'    => :engine,
+        'formatters' => :formatter,
+        'parsers'    => :parser,
+        'middleware' => :middleware
+      }.freeze
+
+      EXCEPTION_BACKTRACE_LIMIT = 10
+      EXCEPTION_PRIORITY = { warn: 0, error: 5, fatal: 9 }.freeze
+      EXCEPTION_COLORS = {
+        fatal:   :darkred,
+        error:   :red,
+        warn:    :yellow,
+        debug:   :aqua,
+        unknown: :magenta
+      }.freeze
+
+      def self.current_log_method
+        Thread.current[:legion_log_method]
+      end
+
+      def self.current_log_segments
+        Thread.current[:legion_log_segments]
+      end
+
+      def self.current_context
+        Thread.current[:legion_context]
+      end
+
       def log
-        return @log unless @log.nil?
+        @log ||= Legion::Logging::TaggedLogger.new(segments: derive_log_segments, **settings[:logger])
+      end
 
-        logger_hash = if respond_to?(:segments)
-                        { lex_segments: Array(segments) }
-                      else
-                        { lex: derive_log_tag }
-                      end
+      def with_log_context(method_name)
+        prev = Thread.current[:legion_log_method]
+        Thread.current[:legion_log_method] = method_name.to_s
+        yield
+      ensure
+        Thread.current[:legion_log_method] = prev
+      end
 
-        if respond_to?(:settings) && settings.is_a?(Hash) && settings.key?(:logger)
-          ls = settings[:logger]
-          logger_hash[:level] = ls[:level] if ls.key?(:level)
-          logger_hash[:log_file] = ls[:log_file] if ls.key?(:log_file)
-          logger_hash[:trace] = ls[:trace] if ls.key?(:trace)
-          logger_hash[:extended] = ls[:extended] if ls.key?(:extended)
-        end
+      def handle_exception(exception, task_id: nil, level: :error, handled: true, **opts)
+        segments = derive_log_segments
+        spec = gem_spec
+        ctx = Thread.current[:legion_context] || {}
 
-        @log = Legion::Logging::Logger.new(**logger_hash)
+        event = Legion::Logging::EventBuilder.build_exception(
+          exception:       exception,
+          level:           level,
+          lex:             log_name,
+          component_type:  derive_component_type,
+          gem_name:        gem_name,
+          lex_version:     spec&.version&.to_s,
+          gem_path:        spec&.full_gem_path,
+          source_code_uri: spec&.metadata&.[]('source_code_uri'),
+          handled:         handled,
+          task_id:         task_id || ctx[:task_id],
+          payload_summary: opts.empty? ? nil : opts,
+          caller_offset:   3
+        )
+
+        event[:conversation_id] ||= ctx[:conversation_id]
+        event[:chain_id] ||= ctx[:chain_id]
+        event[:log_segments] = segments
+        event[:method] = Thread.current[:legion_log_method]
+
+        event = Legion::Logging::Redactor.redact(event) if defined?(Legion::Logging::Redactor)
+
+        write_exception_to_log(exception, event, level, segments)
+        publish_exception(event, level)
       end
 
       private
 
-      def derive_log_tag
+      def derive_log_segments
+        key = respond_to?(:ancestors) ? ancestors.first : self.class
+        SEGMENT_CACHE[key] ||= begin
+          parts = key.to_s.split('::')
+          parts.shift if parts.first == 'Legion'
+          parts.shift if parts.first == 'Extensions'
+          parts.map! do |p|
+            p.gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+             .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+             .downcase
+          end
+          parts.freeze
+        end
+      end
+
+      def derive_component_type
+        segments = derive_log_segments
+        match = segments.find { |s| COMPONENT_MAP.key?(s) }
+        return COMPONENT_MAP[match] if match
+
+        segments.last&.to_sym || :unknown
+      end
+
+      def log_name
         if respond_to?(:lex_filename)
           fname = lex_filename
           return fname.is_a?(Array) ? fname.first : fname
         end
 
-        name = respond_to?(:ancestors) ? ancestors.first.to_s : self.class.to_s
-        parts = name.split('::')
-        ext_idx = parts.index('Extensions')
-        target = if ext_idx && parts[ext_idx + 1]
-                   parts[ext_idx + 1]
-                 else
-                   parts.last
-                 end
-        target.gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
-              .gsub(/([a-z\d])([A-Z])/, '\1_\2')
-              .downcase
+        derive_log_segments.first
+      rescue StandardError
+        nil
+      end
+
+      def gem_name
+        @gem_name_resolved ? @gem_name_value : resolve_gem_name
+      end
+
+      def gem_spec
+        @gem_spec_resolved ? @gem_spec_value : resolve_gem_spec
+      end
+
+      def resolve_gem_name
+        @gem_name_resolved = true
+        base = log_name
+        @gem_name_value = if base
+                            %W[lex-#{base} legion-#{base} #{base}].find do |candidate|
+                              Gem::Specification.find_by_name(candidate)
+                              candidate
+                            rescue Gem::MissingSpecError
+                              nil
+                            end
+                          end
+      rescue StandardError
+        @gem_name_value = nil
+      end
+
+      def resolve_gem_spec
+        @gem_spec_resolved = true
+        name = gem_name
+        @gem_spec_value = name ? Gem::Specification.find_by_name(name) : nil
+      rescue Gem::MissingSpecError
+        @gem_spec_value = nil
+      end
+
+      def settings
+        { logger: logger_settings }
+      end
+
+      def logger_settings
+        return Legion::Settings[:logging] if defined?(Legion::Settings) && Legion::Settings[:logging].is_a?(Hash)
+
+        Legion::Logging::Settings.default
+      end
+
+      # -- Exception stdout/file output --
+
+      def write_exception_to_log(exception, event, level, segments)
+        prev_segs = Thread.current[:legion_log_segments]
+        Thread.current[:legion_log_segments] = segments
+
+        message = format_exception_output(exception, event)
+        message = Legion::Logging::Redactor.redact_string(message) if defined?(Legion::Logging::Redactor) && redaction_enabled?
+        message = colorize_exception(message, level) if Legion::Logging.color
+
+        Legion::Logging.log.public_send(level, message)
+      ensure
+        Thread.current[:legion_log_segments] = prev_segs
+      end
+
+      def format_exception_output(exception, event)
+        lines = ["#{exception.class}: #{exception.message}"]
+
+        context_line = build_context_line(event)
+        lines << "  #{context_line}" unless context_line.empty?
+
+        bt = exception.backtrace
+        if bt&.any?
+          bt.first(EXCEPTION_BACKTRACE_LIMIT).each { |frame| lines << "  #{frame}" }
+          remaining = bt.length - EXCEPTION_BACKTRACE_LIMIT
+          lines << "  ... #{remaining} more" if remaining.positive?
+        end
+
+        lines.join("\n")
+      end
+
+      def colorize_exception(message, level)
+        color = EXCEPTION_COLORS[level] || :red
+        lines = message.split("\n")
+        lines[0] = Rainbow(lines[0]).color(color).bright
+        lines[1..].each_with_index do |line, i|
+          lines[i + 1] = Rainbow(line).color(color).faint
+        end
+        lines.join("\n")
+      end
+
+      def build_context_line(event)
+        parts = []
+        gn = event[:gem_name]
+        gv = event[:lex_version]
+        parts << (gv ? "#{gn}@#{gv}" : gn.to_s) if gn
+        parts << "task:#{event[:task_id]}" if event[:task_id]
+        parts << "conversation:#{event[:conversation_id]}" if event[:conversation_id]
+        parts << "chain:#{event[:chain_id]}" if event[:chain_id]
+        parts.join(' | ')
+      end
+
+      def redaction_enabled?
+        return false unless defined?(Legion::Settings)
+
+        loader = Legion::Settings.instance_variable_get(:@loader)
+        return false unless loader
+
+        loader.dig(:logging, :redaction, :enabled) == true
+      rescue StandardError
+        false
+      end
+
+      # -- Exception structured publish --
+
+      def publish_exception(event, level)
+        lex_name = event[:lex] || 'core'
+        comp = event[:component_type] || :unknown
+        routing_key = "legion.logging.exception.#{level}.#{lex_name}.#{comp}"
+
+        headers = build_exception_headers(event, comp, level)
+        properties = build_exception_properties(event, level)
+
+        Legion::Logging.exception_writer.call(event, routing_key: routing_key, headers: headers, properties: properties)
+      rescue StandardError => e
+        Legion::Logging.warn("Failed to publish exception event: #{e.class}: #{e.message}")
+      end
+
+      def build_exception_headers(event, comp, level)
+        headers = {
+          'x-error-fingerprint' => event[:error_fingerprint],
+          'x-exception-class'   => event[:exception_class],
+          'x-handled'           => event[:handled].to_s,
+          'x-gem-name'          => event[:gem_name].to_s,
+          'x-lex-version'       => event[:lex_version].to_s,
+          'x-component-type'    => comp.to_s,
+          'x-level'             => level.to_s
+        }
+        headers['x-task-id'] = event[:task_id].to_s if event[:task_id]
+        headers['x-conversation-id'] = event[:conversation_id].to_s if event[:conversation_id]
+        headers['x-chain-id'] = event[:chain_id].to_s if event[:chain_id]
+        headers['x-user'] = event[:user].to_s if event[:user]
+        headers
+      end
+
+      def build_exception_properties(event, level)
+        {
+          content_type:   'application/json',
+          message_id:     SecureRandom.uuid,
+          correlation_id: event[:error_fingerprint],
+          timestamp:      Time.now.to_i,
+          app_id:         'legionio',
+          type:           'exception_event',
+          priority:       EXCEPTION_PRIORITY[level] || 5,
+          delivery_mode:  2
+        }
       end
     end
   end

--- a/lib/legion/logging/helper.rb
+++ b/lib/legion/logging/helper.rb
@@ -7,6 +7,8 @@ module Legion
   module Logging
     module Helper
       SEGMENT_CACHE = {} # rubocop:disable Style/MutableConstant
+      SEGMENT_CACHE_MUTEX = Mutex.new
+      private_constant :SEGMENT_CACHE_MUTEX
       COMPONENT_MAP = {
         'runners'    => :runner,
         'actors'     => :actor,
@@ -98,7 +100,9 @@ module Legion
 
       def derive_log_segments
         key = respond_to?(:ancestors) ? ancestors.first : self.class
-        SEGMENT_CACHE[key] ||= begin
+        return SEGMENT_CACHE[key] if SEGMENT_CACHE.key?(key)
+
+        segments = begin
           parts = key.to_s.split('::')
           parts.shift if parts.first == 'Legion'
           parts.shift if parts.first == 'Extensions'
@@ -109,6 +113,8 @@ module Legion
           end
           parts.freeze
         end
+
+        SEGMENT_CACHE_MUTEX.synchronize { SEGMENT_CACHE[key] ||= segments }
       end
 
       def derive_component_type

--- a/lib/legion/logging/helper.rb
+++ b/lib/legion/logging/helper.rb
@@ -54,7 +54,7 @@ module Legion
       end
 
       def log
-        @log ||= Legion::Logging::TaggedLogger.new(segments: derive_log_segments, **settings[:logger])
+        @log ||= Legion::Logging::TaggedLogger.new(segments: derive_log_segments, **resolve_logger_settings)
       end
 
       def with_log_context(method_name)
@@ -175,6 +175,14 @@ module Legion
         return Legion::Settings[:logging] if defined?(Legion::Settings) && Legion::Settings[:logging].is_a?(Hash)
 
         Legion::Logging::Settings.default
+      end
+
+      def resolve_logger_settings
+        s = settings
+        return Legion::Logging::Settings.default unless s.is_a?(Hash)
+
+        raw = s[:logger]
+        raw.is_a?(Hash) ? raw : Legion::Logging::Settings.default
       end
 
       # -- Exception stdout/file output --

--- a/lib/legion/logging/methods.rb
+++ b/lib/legion/logging/methods.rb
@@ -5,6 +5,13 @@ require 'securerandom'
 module Legion
   module Logging
     module Methods
+      COMPONENT_REGEX = %r{
+        /(runners|actors|actor|helpers|hooks|absorbers|matchers|transport|
+        exchanges|queues|messages|data|builders|tools|adapters|engines|
+        formatters|parsers|middleware)/
+      }x
+      EXCEPTION_PRIORITY = { warn: 0, error: 5, fatal: 9 }.freeze
+
       def trace(raw_message = nil, size: @trace_size, log_caller: true)
         return unless @trace_enabled
 
@@ -219,7 +226,7 @@ module Legion
           timestamp:      Time.now.to_i,
           app_id:         'legionio',
           type:           'exception_event',
-          priority:       { warn: 0, error: 5, fatal: 9 }[level] || 5,
+          priority:       EXCEPTION_PRIORITY[level] || 5,
           delivery_mode:  2
         }
       end
@@ -230,7 +237,7 @@ module Legion
         return nil unless has_writer || has_hooks
 
         lex_val  = instance_variable_defined?(:@lex) ? @lex : nil
-        lex_segs = instance_variable_defined?(:@lex_segments) ? @lex_segments : nil
+        lex_segs = Thread.current[:legion_log_segments] || (instance_variable_defined?(:@lex_segments) ? @lex_segments : nil)
 
         event = Legion::Logging::EventBuilder.build(
           level:         level,
@@ -244,7 +251,7 @@ module Legion
 
       def fire_log_writer(level, message)
         lex_val  = instance_variable_defined?(:@lex) ? @lex : nil
-        lex_segs = instance_variable_defined?(:@lex_segments) ? @lex_segments : nil
+        lex_segs = Thread.current[:legion_log_segments] || (instance_variable_defined?(:@lex_segments) ? @lex_segments : nil)
 
         event = Legion::Logging::EventBuilder.build(
           level:         level,
@@ -254,14 +261,13 @@ module Legion
           caller_offset: 4
         )
         lex_name = event[:lex] || 'core'
-        component = event.dig(:caller, :file).to_s[%r{/(runners|actors|transport|helpers|builders)/}, 1] || 'unknown'
+        component = event.dig(:caller, :file).to_s[COMPONENT_REGEX, 1] || 'unknown'
         routing_key = "legion.logging.log.#{level}.#{lex_name}.#{component}"
         Legion::Logging.log_writer.call(event, routing_key: routing_key)
         Legion::Logging::Hooks.fire(level, message, event) if defined?(Legion::Logging::Hooks)
       rescue StandardError => e
-        if respond_to?(:log) && log.respond_to?(:warn)
-          log.warn("fire_log_writer failed for level=#{level}, routing_key=#{routing_key}: #{e.class}: #{e.message}")
-        end
+        rk = defined?(routing_key) ? routing_key : 'unknown'
+        log.warn("fire_log_writer failed for level=#{level}, routing_key=#{rk}: #{e.class}: #{e.message}") if respond_to?(:log) && log.respond_to?(:warn)
       end
     end
   end

--- a/lib/legion/logging/methods.rb
+++ b/lib/legion/logging/methods.rb
@@ -34,7 +34,11 @@ module Legion
         message = Rainbow(message).blue if @color
         writer = @async_writer
         if writer&.alive?
-          writer.push(AsyncWriter::LogEntry.new(level: :debug, message: message, writer_context: nil))
+          writer.push(AsyncWriter::LogEntry.new(
+                        level: :debug, message: message, writer_context: nil,
+                        segments: Thread.current[:legion_log_segments],
+                        method_ctx: Thread.current[:legion_log_method]
+                      ))
         else
           log.debug(message)
         end
@@ -48,7 +52,11 @@ module Legion
         message = Rainbow(message).green if @color
         writer = @async_writer
         if writer&.alive?
-          writer.push(AsyncWriter::LogEntry.new(level: :info, message: message, writer_context: nil))
+          writer.push(AsyncWriter::LogEntry.new(
+                        level: :info, message: message, writer_context: nil,
+                        segments: Thread.current[:legion_log_segments],
+                        method_ctx: Thread.current[:legion_log_method]
+                      ))
         else
           log.info(message)
         end
@@ -64,7 +72,11 @@ module Legion
         writer = @async_writer
         if writer&.alive?
           ctx = build_writer_context(:warn, raw)
-          writer.push(AsyncWriter::LogEntry.new(level: :warn, message: message, writer_context: ctx))
+          writer.push(AsyncWriter::LogEntry.new(
+                        level: :warn, message: message, writer_context: ctx,
+                        segments: Thread.current[:legion_log_segments],
+                        method_ctx: Thread.current[:legion_log_method]
+                      ))
         else
           log.warn(message)
           fire_log_writer(:warn, raw)
@@ -81,7 +93,11 @@ module Legion
         writer = @async_writer
         if writer&.alive?
           ctx = build_writer_context(:error, raw)
-          writer.push(AsyncWriter::LogEntry.new(level: :error, message: message, writer_context: ctx))
+          writer.push(AsyncWriter::LogEntry.new(
+                        level: :error, message: message, writer_context: ctx,
+                        segments: Thread.current[:legion_log_segments],
+                        method_ctx: Thread.current[:legion_log_method]
+                      ))
         else
           log.error(message)
           fire_log_writer(:error, raw)
@@ -105,7 +121,11 @@ module Legion
         message = Rainbow(message).purple if @color
         writer = @async_writer
         if writer&.alive?
-          writer.push(AsyncWriter::LogEntry.new(level: :unknown, message: message, writer_context: nil))
+          writer.push(AsyncWriter::LogEntry.new(
+                        level: :unknown, message: message, writer_context: nil,
+                        segments: Thread.current[:legion_log_segments],
+                        method_ctx: Thread.current[:legion_log_method]
+                      ))
         else
           log.unknown(message)
         end

--- a/lib/legion/logging/settings.rb
+++ b/lib/legion/logging/settings.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Legion
+  module Logging
+    module Settings
+      def self.default
+        {
+          level:      :info,
+          trace:      false,
+          trace_size: 4,
+          extended:   false
+        }
+      end
+    end
+  end
+end

--- a/lib/legion/logging/shipper/http_transport.rb
+++ b/lib/legion/logging/shipper/http_transport.rb
@@ -29,7 +29,7 @@ module Legion
           def post(uri, body)
             req = Net::HTTP::Post.new(uri)
             req['Content-Type'] = 'application/json'
-            apply_auth(req)
+            apply_auth(req, uri)
 
             Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https',
                                                      open_timeout: 5, read_timeout: 10) do |http|
@@ -50,11 +50,11 @@ module Legion
             uri.path.include?('/services/collector')
           end
 
-          def apply_auth(req)
+          def apply_auth(req, uri)
             token = auth_token
             return unless token
 
-            req['Authorization'] = if splunk_hec?(URI(req.path.empty? ? '/' : req.uri&.to_s || '/'))
+            req['Authorization'] = if splunk_hec?(uri)
                                      "Splunk #{token}"
                                    else
                                      "Bearer #{token}"

--- a/lib/legion/logging/tagged_logger.rb
+++ b/lib/legion/logging/tagged_logger.rb
@@ -9,7 +9,12 @@ module Legion
 
       def initialize(segments:, level: :info, trace: false, trace_size: 4, extended: false, **_opts)
         @segments = segments
-        @level_value = LEVELS.fetch(level.to_s.downcase.to_sym, 1)
+        @level_value =
+          if level.is_a?(Integer)
+            level
+          else
+            LEVELS.fetch(level.to_s.downcase.to_sym, LEVELS[:info])
+          end
         @trace_enabled = trace
         @trace_size = trace_size
         @extended = extended

--- a/lib/legion/logging/tagged_logger.rb
+++ b/lib/legion/logging/tagged_logger.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Legion
+  module Logging
+    class TaggedLogger
+      LEVELS = { debug: 0, info: 1, warn: 2, error: 3, fatal: 4, unknown: 5 }.freeze
+
+      attr_reader :segments, :trace_enabled, :extended
+
+      def initialize(segments:, level: :info, trace: false, trace_size: 4, extended: false, **_opts)
+        @segments = segments
+        @level_value = LEVELS.fetch(level.to_s.downcase.to_sym, 1)
+        @trace_enabled = trace
+        @trace_size = trace_size
+        @extended = extended
+      end
+
+      def level
+        @level_value
+      end
+
+      def debug(message = nil)
+        return unless @level_value < 1
+
+        message = yield if message.nil? && block_given?
+        with_segments { Legion::Logging.debug(message) }
+      end
+
+      def info(message = nil)
+        return unless @level_value < 2
+
+        message = yield if message.nil? && block_given?
+        with_segments { Legion::Logging.info(message) }
+      end
+
+      def warn(message = nil)
+        return unless @level_value < 3
+
+        message = yield if message.nil? && block_given?
+        with_segments { Legion::Logging.warn(message) }
+      end
+
+      def error(message = nil)
+        return unless @level_value < 4
+
+        message = yield if message.nil? && block_given?
+        with_segments { Legion::Logging.error(message) }
+      end
+
+      def fatal(message = nil)
+        return unless @level_value < 5
+
+        message = yield if message.nil? && block_given?
+        with_segments { Legion::Logging.fatal(message) }
+      end
+
+      def unknown(message = nil)
+        message = yield if message.nil? && block_given?
+        with_segments { Legion::Logging.unknown(message) }
+      end
+
+      def trace(raw_message = nil, size: @trace_size, log_caller: true)
+        return unless @trace_enabled
+
+        raw_message = yield if raw_message.nil? && block_given?
+        message = "Tracing: #{raw_message} "
+        if log_caller
+          frames = size ? caller_locations(1, size) : caller_locations(1)
+          message.concat(frames&.join(', ').to_s)
+        end
+        with_segments { Legion::Logging.unknown(message) }
+      end
+
+      def thread(kvl: false, **_opts)
+        if kvl
+          "thread=#{Thread.current.object_id}"
+        else
+          Thread.current.object_id.to_s
+        end
+      end
+
+      private
+
+      def with_segments
+        prev = Thread.current[:legion_log_segments]
+        Thread.current[:legion_log_segments] = @segments
+        yield
+      ensure
+        Thread.current[:legion_log_segments] = prev
+      end
+    end
+  end
+end

--- a/lib/legion/logging/tagged_logger.rb
+++ b/lib/legion/logging/tagged_logger.rb
@@ -65,7 +65,7 @@ module Legion
         raw_message = yield if raw_message.nil? && block_given?
         message = "Tracing: #{raw_message} "
         if log_caller
-          frames = size ? caller_locations(1, size) : caller_locations(1)
+          frames = size ? caller_locations(2, size) : caller_locations(2)
           message.concat(frames&.join(', ').to_s)
         end
         with_segments { Legion::Logging.unknown(message) }

--- a/lib/legion/logging/version.rb
+++ b/lib/legion/logging/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Logging
-    VERSION = '1.4.2'
+    VERSION = '1.4.3'
   end
 end

--- a/spec/legion/logging/async_writer_spec.rb
+++ b/spec/legion/logging/async_writer_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Legion::Logging::AsyncWriter do
 
     it 'writes entries to the logger' do
       entry = Legion::Logging::AsyncWriter::LogEntry.new(
-        level: :info, message: 'async test', writer_context: nil
+        level: :info, message: 'async test', writer_context: nil, segments: nil, method_ctx: nil
       )
       subject.push(entry)
       subject.stop
@@ -51,7 +51,7 @@ RSpec.describe Legion::Logging::AsyncWriter do
       messages = []
       allow(logger).to receive(:info) { |msg| messages << msg }
 
-      3.times { |i| subject.push(Legion::Logging::AsyncWriter::LogEntry.new(level: :info, message: "msg-#{i}", writer_context: nil)) }
+      3.times { |i| subject.push(Legion::Logging::AsyncWriter::LogEntry.new(level: :info, message: "msg-#{i}", writer_context: nil, segments: nil, method_ctx: nil)) }
       subject.stop
 
       expect(messages).to eq(%w[msg-0 msg-1 msg-2])
@@ -62,11 +62,11 @@ RSpec.describe Legion::Logging::AsyncWriter do
     subject { described_class.new(logger, buffer_size: 2) }
 
     it 'blocks the caller when the queue is full' do
-      2.times { |i| subject.push(Legion::Logging::AsyncWriter::LogEntry.new(level: :info, message: "fill-#{i}", writer_context: nil)) }
+      2.times { |i| subject.push(Legion::Logging::AsyncWriter::LogEntry.new(level: :info, message: "fill-#{i}", writer_context: nil, segments: nil, method_ctx: nil)) }
 
       blocked = true
       pusher = Thread.new do
-        subject.push(Legion::Logging::AsyncWriter::LogEntry.new(level: :info, message: 'overflow', writer_context: nil))
+        subject.push(Legion::Logging::AsyncWriter::LogEntry.new(level: :info, message: 'overflow', writer_context: nil, segments: nil, method_ctx: nil))
         blocked = false
       end
 
@@ -86,7 +86,7 @@ RSpec.describe Legion::Logging::AsyncWriter do
       allow(logger).to receive(:warn) { |msg| messages << msg }
 
       subject.start
-      5.times { |i| subject.push(Legion::Logging::AsyncWriter::LogEntry.new(level: :warn, message: "drain-#{i}", writer_context: nil)) }
+      5.times { |i| subject.push(Legion::Logging::AsyncWriter::LogEntry.new(level: :warn, message: "drain-#{i}", writer_context: nil, segments: nil, method_ctx: nil)) }
       subject.stop
 
       expect(messages).to eq((0..4).map { |i| "drain-#{i}" })
@@ -107,7 +107,8 @@ RSpec.describe Legion::Logging::AsyncWriter do
       event = { level: :error, message: 'writer test', lex: 'core' }
       entry = Legion::Logging::AsyncWriter::LogEntry.new(
         level: :error, message: 'writer test',
-        writer_context: { level: :error, event: event }
+        writer_context: { level: :error, event: event },
+        segments: nil, method_ctx: nil
       )
       subject.push(entry)
       deadline = Time.now + 2
@@ -123,7 +124,7 @@ RSpec.describe Legion::Logging::AsyncWriter do
     subject { described_class.new(logger) }
 
     it 'is a frozen Data struct' do
-      entry = Legion::Logging::AsyncWriter::LogEntry.new(level: :info, message: 'test', writer_context: nil)
+      entry = Legion::Logging::AsyncWriter::LogEntry.new(level: :info, message: 'test', writer_context: nil, segments: nil, method_ctx: nil)
       expect(entry).to be_frozen
     end
   end

--- a/spec/legion/logging/event_builder_spec.rb
+++ b/spec/legion/logging/event_builder_spec.rb
@@ -4,6 +4,11 @@ require 'legion/logging'
 require 'legion/logging/event_builder'
 
 RSpec.describe Legion::Logging::EventBuilder do
+  before do
+    described_class.remove_instance_variable(:@gem_spec_cache) if described_class.instance_variable_defined?(:@gem_spec_cache)
+    described_class.remove_instance_variable(:@legion_versions) if described_class.instance_variable_defined?(:@legion_versions)
+  end
+
   describe '.build' do
     it 'includes required fields' do
       event = described_class.build(level: :fatal, message: 'something broke')

--- a/spec/legion/logging/helper_spec.rb
+++ b/spec/legion/logging/helper_spec.rb
@@ -3,14 +3,10 @@
 require 'spec_helper'
 
 RSpec.describe Legion::Logging::Helper do
-  let(:segmented_class) do
-    Class.new do
+  let(:bare_class) do
+    stub_const('Legion::Extensions::MyExtension::Runners::Foo', Class.new do
       include Legion::Logging::Helper
-
-      def segments
-        %w[microsoft_teams]
-      end
-    end
+    end)
   end
 
   let(:lex_filename_class) do
@@ -23,73 +19,254 @@ RSpec.describe Legion::Logging::Helper do
     end
   end
 
-  let(:bare_class) do
-    stub_const('Legion::Extensions::MyExtension::Runners::Foo', Class.new do
+  let(:settings_class) do
+    Class.new do
       include Legion::Logging::Helper
-    end)
+
+      def settings
+        { logger: { level: 'debug', trace: true, extended: true } }
+      end
+    end
   end
 
   describe '#log' do
-    context 'when the object responds to :segments' do
-      subject { segmented_class.new }
-
-      it 'builds a logger with lex_segments:' do
-        logger_double = instance_double(Legion::Logging::Logger)
-        expect(Legion::Logging::Logger).to receive(:new)
-          .with(hash_including(lex_segments: %w[microsoft_teams]))
-          .and_return(logger_double)
-        expect(subject.log).to eq(logger_double)
-      end
+    it 'returns a TaggedLogger' do
+      expect(bare_class.new.log).to be_a(Legion::Logging::TaggedLogger)
     end
 
-    context 'when the object responds to :lex_filename but not :segments' do
-      subject { lex_filename_class.new }
-
-      it 'builds a logger with lex: from lex_filename' do
-        logger_double = instance_double(Legion::Logging::Logger)
-        expect(Legion::Logging::Logger).to receive(:new)
-          .with(hash_including(lex: 'microsoft_teams'))
-          .and_return(logger_double)
-        expect(subject.log).to eq(logger_double)
-      end
+    it 'derives segments from class namespace' do
+      logger = bare_class.new.log
+      expect(logger.segments).to eq(%w[my_extension runners foo])
     end
 
-    context 'when the object has neither segments nor lex_filename' do
-      subject { bare_class.new }
-
-      it 'derives tag from class name' do
-        logger_double = instance_double(Legion::Logging::Logger)
-        expect(Legion::Logging::Logger).to receive(:new)
-          .with(hash_including(lex: 'my_extension'))
-          .and_return(logger_double)
-        expect(subject.log).to eq(logger_double)
-      end
+    it 'uses default settings when no override is defined' do
+      logger = bare_class.new.log
+      expect(logger.level).to eq(1)
+      expect(logger.extended).to be false
+      expect(logger.trace_enabled).to be false
     end
 
-    context 'when the object has settings with logger config' do
-      subject do
-        Class.new do
-          include Legion::Logging::Helper
-
-          def settings
-            { logger: { level: 'debug', extended: true } }
-          end
-        end.new
-      end
-
-      it 'passes logger settings through' do
-        logger_double = instance_double(Legion::Logging::Logger)
-        expect(Legion::Logging::Logger).to receive(:new)
-          .with(hash_including(level: 'debug', extended: true))
-          .and_return(logger_double)
-        subject.log
-      end
+    it 'uses overridden settings when defined' do
+      logger = settings_class.new.log
+      expect(logger.level).to eq(0)
+      expect(logger.extended).to be true
+      expect(logger.trace_enabled).to be true
     end
 
     it 'memoizes the logger instance' do
-      obj = segmented_class.new
+      obj = bare_class.new
       first = obj.log
       expect(obj.log).to equal(first)
+    end
+  end
+
+  describe '#with_log_context' do
+    subject { bare_class.new }
+
+    it 'sets the thread-local method name during the block' do
+      captured = nil
+      subject.with_log_context(:my_method) do
+        captured = Legion::Logging::Helper.current_log_method
+      end
+      expect(captured).to eq('my_method')
+    end
+
+    it 'restores the previous value after the block' do
+      subject.with_log_context(:outer) do
+        subject.with_log_context(:inner) do
+          expect(Legion::Logging::Helper.current_log_method).to eq('inner')
+        end
+        expect(Legion::Logging::Helper.current_log_method).to eq('outer')
+      end
+      expect(Legion::Logging::Helper.current_log_method).to be_nil
+    end
+
+    it 'restores on exception' do
+      subject.with_log_context(:safe) do
+        raise 'boom'
+      end
+    rescue RuntimeError
+      nil
+    ensure
+      expect(Legion::Logging::Helper.current_log_method).to be_nil
+    end
+  end
+
+  describe '#handle_exception' do
+    subject { bare_class.new }
+
+    let(:underlying_logger) { instance_double(Logger) }
+
+    before do
+      allow(Legion::Logging).to receive(:log).and_return(underlying_logger)
+      allow(Legion::Logging).to receive(:color).and_return(false)
+      allow(Legion::Logging).to receive(:warn)
+      allow(Legion::Logging).to receive(:exception_writer).and_return(->(_e, **_k) {})
+      allow(underlying_logger).to receive(:error)
+      allow(underlying_logger).to receive(:fatal)
+    end
+
+    it 'writes human-readable output to the underlying logger' do
+      exc = StandardError.new('test error')
+      subject.handle_exception(exc)
+      expect(underlying_logger).to have_received(:error).with(/StandardError: test error/)
+    end
+
+    it 'includes backtrace in output' do
+      exc = StandardError.new('test error')
+      exc.set_backtrace(['/app/lib/foo.rb:42:in `bar`', '/app/lib/baz.rb:10:in `run`'])
+      subject.handle_exception(exc)
+      expect(underlying_logger).to have_received(:error).with(%r{/app/lib/foo.rb:42})
+    end
+
+    it 'includes context line with task_id' do
+      exc = StandardError.new('test error')
+      subject.handle_exception(exc, task_id: 12_345)
+      expect(underlying_logger).to have_received(:error).with(/task:12345/)
+    end
+
+    it 'reads task_id from thread context when not passed explicitly' do
+      exc = StandardError.new('test error')
+      Thread.current[:legion_context] = { task_id: 99, conversation_id: 'conv-abc' }
+      subject.handle_exception(exc)
+      expect(underlying_logger).to have_received(:error).with(/task:99/)
+      expect(underlying_logger).to have_received(:error).with(/conversation:conv-abc/)
+    ensure
+      Thread.current[:legion_context] = nil
+    end
+
+    it 'explicit task_id wins over thread context' do
+      exc = StandardError.new('test error')
+      Thread.current[:legion_context] = { task_id: 99 }
+      subject.handle_exception(exc, task_id: 42)
+      expect(underlying_logger).to have_received(:error).with(/task:42/)
+    ensure
+      Thread.current[:legion_context] = nil
+    end
+
+    it 'publishes structured event via exception_writer' do
+      writer = instance_double(Proc)
+      allow(writer).to receive(:call)
+      allow(Legion::Logging).to receive(:exception_writer).and_return(writer)
+
+      exc = StandardError.new('publish test')
+      subject.handle_exception(exc)
+
+      expect(writer).to have_received(:call).with(
+        hash_including(exception_class: 'StandardError'),
+        routing_key: /legion\.logging\.exception\.error/,
+        headers:     hash_including('x-exception-class' => 'StandardError'),
+        properties:  hash_including(type: 'exception_event')
+      )
+    end
+
+    it 'caps backtrace at EXCEPTION_BACKTRACE_LIMIT' do
+      exc = StandardError.new('deep stack')
+      exc.set_backtrace(Array.new(25) { |i| "/app/lib/file.rb:#{i}:in `method_#{i}`" })
+      subject.handle_exception(exc)
+      expect(underlying_logger).to have_received(:error).with(/\.\.\. 15 more/)
+    end
+
+    it 'supports custom log level' do
+      exc = StandardError.new('fatal error')
+      subject.handle_exception(exc, level: :fatal)
+      expect(underlying_logger).to have_received(:fatal).with(/StandardError: fatal error/)
+    end
+
+    context 'with color enabled' do
+      around do |example|
+        was_enabled = Rainbow.enabled
+        Rainbow.enabled = true
+        example.run
+      ensure
+        Rainbow.enabled = was_enabled
+      end
+
+      before do
+        allow(Legion::Logging).to receive(:color).and_return(true)
+      end
+
+      it 'applies rainbow coloring to exception output' do
+        exc = StandardError.new('colored error')
+        exc.set_backtrace(['/app/lib/foo.rb:42:in `bar`'])
+        subject.handle_exception(exc)
+        expect(underlying_logger).to have_received(:error) do |msg|
+          expect(msg).to include("\e[") # contains ANSI escape codes
+        end
+      end
+    end
+  end
+
+  describe '.current_log_method' do
+    it 'returns nil when no context is set' do
+      expect(Legion::Logging::Helper.current_log_method).to be_nil
+    end
+  end
+
+  describe '.current_log_segments' do
+    it 'returns nil when no segments are set' do
+      expect(Legion::Logging::Helper.current_log_segments).to be_nil
+    end
+  end
+
+  describe '.current_context' do
+    it 'returns nil when no context is set' do
+      expect(Legion::Logging::Helper.current_context).to be_nil
+    end
+
+    it 'returns the thread-local context hash' do
+      Thread.current[:legion_context] = { task_id: 1 }
+      expect(Legion::Logging::Helper.current_context).to eq({ task_id: 1 })
+    ensure
+      Thread.current[:legion_context] = nil
+    end
+  end
+
+  describe 'derive_log_segments (via TaggedLogger segments)' do
+    it 'strips Legion and Extensions from namespace' do
+      logger = bare_class.new.log
+      expect(logger.segments).to eq(%w[my_extension runners foo])
+    end
+
+    it 'handles core library namespaces' do
+      core_class = stub_const('Legion::LLM::Router', Class.new do
+        include Legion::Logging::Helper
+      end)
+      logger = core_class.new.log
+      expect(logger.segments).to eq(%w[llm router])
+    end
+
+    it 'caches segments per class' do
+      obj1 = bare_class.new
+      obj2 = bare_class.new
+      expect(obj1.log.segments).to equal(obj2.log.segments)
+    end
+  end
+
+  describe '#log_name' do
+    it 'uses lex_filename when available' do
+      obj = lex_filename_class.new
+      expect(obj.send(:log_name)).to eq('microsoft_teams')
+    end
+
+    it 'falls back to first segment' do
+      obj = bare_class.new
+      expect(obj.send(:log_name)).to eq('my_extension')
+    end
+  end
+
+  describe '#gem_name' do
+    it 'returns nil when no gem is found' do
+      obj = bare_class.new
+      expect(obj.send(:gem_name)).to be_nil
+    end
+  end
+
+  describe 'default settings' do
+    it 'returns Legion::Logging::Settings.default when Legion::Settings is not defined' do
+      obj = bare_class.new
+      expected = Legion::Logging::Settings.default
+      expect(obj.send(:settings)).to eq({ logger: expected })
     end
   end
 end


### PR DESCRIPTION
## Summary

- Replaces per-includer `Logger` instances with lightweight `TaggedLogger` proxy that delegates to the singleton (shared stdout, file writer, and async queue)
- Adds `derive_log_segments` with class-level cache — `Legion::LLM::Router` → `[llm][router]`, zero config
- Adds `with_log_context(__method__)` for block-scoped method names in log output: `[llm][router]{dispatch}`
- Moves `handle_exception` to Helper with direct `EventBuilder` calls, per-line Rainbow coloring, and structured AMQP publish
- Moves `log_name`/`gem_name`/`gem_spec` from LegionIO with multi-prefix gem resolution (`lex-*`, `legion-*`, raw)
- Expands `COMPONENT_MAP` to 18 types (runners, actors, hooks, absorbers, tools, adapters, middleware, etc.)
- Adds `Thread.current[:legion_context]` support for wire protocol fields (task_id, conversation_id, chain_id)
- Fixes component regex in `fire_log_writer` and `fire_writer` (was 5 types, now 18)
- Fixes Splunk auth header bug in `http_transport` (`apply_auth` always sent Bearer instead of Splunk token)
- Memoizes `gem_name`/`gem_spec` per instance, `legion_versions`/`resolve_gem_spec` in EventBuilder
- Fixes `caller_locations` in builder to allocate single frame instead of full stack
- Adds redaction to exception stdout output
- Adds `Settings` module with logger defaults

## Test plan

- [ ] `bundle exec rspec` — 302 examples, 0 failures
- [ ] `bundle exec rubocop` — 0 offenses
- [ ] Verify `TaggedLogger` accepts unexpected settings keys without raising
- [ ] Verify exception output shows colored, multi-line format with segments
- [ ] Verify LegionIO extensions still boot and log correctly (LegionIO side changes pending)