### PR TITLE
Dev v 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Legion::Logging Changelog
 
+## [1.5.0] - 2026-04-02
+
+### Added
+- `Legion::Logging.current_settings` and `.configuration_generation` so helper mixins can refresh memoized tagged loggers after runtime reconfiguration
+- Component logger overrides from local `settings`, top-level `Legion::Settings[component]`, and `Legion::Settings.dig(:extensions, component)` for `log_level`, `trace`, `trace_size`, and `extended`
+- `Methods#emit_tagged` / `TaggedLogger#dispatch` path so component-level loggers can emit with their own level while preserving tagged context
+- Fallback exception event construction in `Helper#handle_exception` when structured exception support is unavailable
+
+### Changed
+- `setup` and `Builder#log_level` now default to `debug`
+- Default helper/tagged logger behavior enables trace and extended metadata
+- `Helper#log` rebuilds memoized `TaggedLogger` instances when logging configuration changes
+- Runtime logger settings take precedence over loaded global settings for helper-mixed components
+
+### Fixed
+- `setup(async: true)` now tolerates boolean `logging.async` settings without probing for `buffer_size`
+- Exception stdout/file output now falls back safely when singleton logger helpers are unavailable
+- Structured exception publishing is skipped when the exception writer/EventBuilder path is unavailable
+- `TaggedLogger#unknown` falls back to `debug` output when `Legion::Logging.unknown` is unavailable
+
 ## [1.4.3] - 2026-04-01
 
 ### Added

--- a/lib/legion/logging.rb
+++ b/lib/legion/logging.rb
@@ -95,6 +95,7 @@ module Legion
           color:       @color
         }.freeze
         @configuration_generation = configuration_generation + 1
+        Legion::Logging::Redactor.refresh_patterns! if defined?(Legion::Logging::Redactor)
         if async
           buffer = if defined?(Legion::Settings) && Legion::Settings.respond_to?(:[])
                      logging_settings = Legion::Settings[:logging]

--- a/lib/legion/logging.rb
+++ b/lib/legion/logging.rb
@@ -36,6 +36,14 @@ module Legion
         @exception_writer || DEFAULT_EXCEPTION_WRITER
       end
 
+      def current_settings
+        (@current_settings || {}).dup
+      end
+
+      def configuration_generation
+        @configuration_generation || 0
+      end
+
       def register_category(name, description: nil, expected_fields: [])
         CategoryRegistry.register_category(name, description: description, expected_fields: expected_fields)
       end
@@ -68,18 +76,32 @@ module Legion
         Hooks.clear_hooks!
       end
 
-      def setup(level: 'info', format: :text, async: true, **options)
+      def setup(level: 'debug', format: :text, async: true, **options)
         output(**options)
         log_level(level)
         log_format(format: format, **options)
         @color = options[:color]
         @color = format != :json && (options[:color] || (options[:color].nil? && options[:log_file].nil?))
+        @current_settings = {
+          level:       level,
+          format:      format.to_sym,
+          async:       async,
+          trace:       options.fetch(:trace, true),
+          trace_size:  options.fetch(:trace_size, 4),
+          extended:    options.fetch(:extended, true),
+          log_file:    options[:log_file],
+          log_stdout:  options[:log_stdout],
+          include_pid: options.fetch(:include_pid, false),
+          color:       @color
+        }.freeze
+        @configuration_generation = configuration_generation + 1
         if async
-          buffer = if defined?(Legion::Settings)
-                     Legion::Settings.dig(:logging, :async, :buffer_size) || 10_000
-                   else
-                     10_000
+          buffer = if defined?(Legion::Settings) && Legion::Settings.respond_to?(:[])
+                     logging_settings = Legion::Settings[:logging]
+                     async_settings = logging_settings[:async] if logging_settings.is_a?(Hash)
+                     async_settings[:buffer_size] if async_settings.is_a?(Hash)
                    end
+          buffer ||= 10_000
           start_async_writer(buffer_size: buffer)
         else
           stop_async_writer

--- a/lib/legion/logging/async_writer.rb
+++ b/lib/legion/logging/async_writer.rb
@@ -8,8 +8,11 @@ module Legion
       LogEntry = ::Data.define(:level, :message, :writer_context, :segments, :method_ctx, :caller_trace)
       SHUTDOWN = :shutdown
 
+      attr_reader :logger
+
       def initialize(logger, buffer_size: 10_000)
         @logger = logger
+        @buffer_size = buffer_size
         @queue  = SizedQueue.new(buffer_size)
         @thread = nil
         @state_mutex = Mutex.new
@@ -21,13 +24,14 @@ module Legion
 
         @state_mutex.synchronize { @accepting = true }
         drain
+        @queue = SizedQueue.new(@buffer_size)
         @thread = Thread.new { consume }
         @thread.name = 'legion-log-writer'
         @thread.abort_on_exception = false
       end
 
       # rubocop:disable Naming/PredicateMethod
-      def stop(timeout: nil)
+      def stop(timeout: 2)
         @state_mutex.synchronize { @accepting = false }
 
         unless @thread&.alive?
@@ -36,7 +40,7 @@ module Legion
           return true
         end
 
-        @queue.push(SHUTDOWN)
+        @queue.close
         timeout ? @thread.join(timeout) : @thread.join
         return false if @thread&.alive?
 
@@ -49,6 +53,8 @@ module Legion
 
         @queue.push(entry)
         true
+      rescue ClosedQueueError
+        false
       end
       # rubocop:enable Naming/PredicateMethod
 
@@ -61,7 +67,7 @@ module Legion
       def consume
         loop do
           entry = @queue.pop
-          break if entry == SHUTDOWN
+          break if entry.nil? || entry == SHUTDOWN
 
           write_entry(entry)
         end

--- a/lib/legion/logging/async_writer.rb
+++ b/lib/legion/logging/async_writer.rb
@@ -5,40 +5,52 @@ require_relative 'methods'
 module Legion
   module Logging
     class AsyncWriter
-      LogEntry = ::Data.define(:level, :message, :writer_context, :segments, :method_ctx)
+      LogEntry = ::Data.define(:level, :message, :writer_context, :segments, :method_ctx, :caller_trace)
       SHUTDOWN = :shutdown
 
       def initialize(logger, buffer_size: 10_000)
         @logger = logger
         @queue  = SizedQueue.new(buffer_size)
         @thread = nil
+        @state_mutex = Mutex.new
+        @accepting = true
       end
 
       def start
         return if @thread&.alive?
 
+        @state_mutex.synchronize { @accepting = true }
         drain
         @thread = Thread.new { consume }
         @thread.name = 'legion-log-writer'
         @thread.abort_on_exception = false
       end
 
-      def stop(timeout: 2)
-        return unless @thread&.alive?
+      # rubocop:disable Naming/PredicateMethod
+      def stop(timeout: nil)
+        @state_mutex.synchronize { @accepting = false }
 
-        begin
-          @queue.push(SHUTDOWN, true)
-        rescue ThreadError
-          # Queue full — fall through to join/kill + drain
+        unless @thread&.alive?
+          drain
+          @thread = nil
+          return true
         end
-        @thread.join(timeout)
-        @thread.kill if @thread&.alive?
-        drain
+
+        @queue.push(SHUTDOWN)
+        timeout ? @thread.join(timeout) : @thread.join
+        return false if @thread&.alive?
+
+        @thread = nil
+        true
       end
 
       def push(entry)
+        return false unless accepting?
+
         @queue.push(entry)
+        true
       end
+      # rubocop:enable Naming/PredicateMethod
 
       def alive?
         @thread&.alive? || false
@@ -58,8 +70,10 @@ module Legion
       def write_entry(entry)
         prev_segments   = Thread.current[:legion_log_segments]
         prev_method_ctx = Thread.current[:legion_log_method]
+        prev_caller     = Thread.current[:legion_log_caller]
         Thread.current[:legion_log_segments] = entry.segments
         Thread.current[:legion_log_method]   = entry.method_ctx
+        Thread.current[:legion_log_caller]   = entry.caller_trace
         @logger.send(entry.level, entry.message)
         fire_writer(entry) if entry.writer_context
       rescue StandardError => e
@@ -67,6 +81,7 @@ module Legion
       ensure
         Thread.current[:legion_log_segments] = prev_segments
         Thread.current[:legion_log_method]   = prev_method_ctx
+        Thread.current[:legion_log_caller]   = prev_caller
       end
 
       def drain
@@ -76,6 +91,10 @@ module Legion
         end
       rescue ThreadError
         nil
+      end
+
+      def accepting?
+        @state_mutex.synchronize { @accepting }
       end
 
       def fire_writer(entry)

--- a/lib/legion/logging/builder.rb
+++ b/lib/legion/logging/builder.rb
@@ -113,7 +113,7 @@ module Legion
         log.level
       end
 
-      def log_level(level = 'info')
+      def log_level(level = 'debug')
         log.level = case level
                     when 'trace', 'debug'
                       ::Logger::DEBUG

--- a/lib/legion/logging/builder.rb
+++ b/lib/legion/logging/builder.rb
@@ -90,6 +90,8 @@ module Legion
       end
 
       def set_log(logfile: nil, log_stdout: nil, **)
+        previous_log = @log
+
         if logfile && log_stdout != false
           path = prepare_log_path(logfile)
           require_relative 'multi_io'
@@ -104,6 +106,9 @@ module Legion
         else
           @log = ::Logger.new($stdout)
         end
+
+        close_replaced_log(previous_log)
+        @log
       end
 
       def prepare_log_path(path)
@@ -143,19 +148,41 @@ module Legion
         (@async == true && @async_writer&.alive?) || false
       end
 
+      # rubocop:disable Naming/PredicateMethod
       def start_async_writer(buffer_size: 10_000)
         require_relative 'async_writer'
-        stop_async_writer if @async_writer&.alive?
+        return false if @async_writer&.alive? && stop_async_writer == false
+
         @async_writer = AsyncWriter.new(log, buffer_size: buffer_size)
         @async_writer.start
         @async = true
+        true
       end
 
       def stop_async_writer
         writer = @async_writer
-        writer&.stop
+        stopped = writer&.stop
+        return false if stopped == false
+
+        close_replaced_log(writer.logger) if writer.respond_to?(:logger)
         @async_writer = nil if @async_writer.equal?(writer)
         @async = false
+        true
+      end
+      # rubocop:enable Naming/PredicateMethod
+
+      private
+
+      def close_replaced_log(logger)
+        return unless logger
+        return if logger.equal?(@log)
+        return if @async_writer&.alive? && @async_writer.respond_to?(:logger) && @async_writer.logger.equal?(logger)
+
+        log_device = logger.instance_variable_get(:@logdev)
+        dev = log_device&.dev
+        return if dev.nil? || [$stdout, $stderr].include?(dev)
+
+        dev.close if dev.respond_to?(:close)
       end
     end
   end

--- a/lib/legion/logging/builder.rb
+++ b/lib/legion/logging/builder.rb
@@ -41,7 +41,7 @@ module Legion
       def text_format(include_pid: false, **options)
         log.formatter = proc do |severity, datetime, _progname, msg|
           lex_name = resolve_lex_tag(options)
-          runner_trace = build_runner_trace if lex_name
+          runner_trace = Thread.current[:legion_log_caller] || build_runner_trace if lex_name
 
           string = "[#{datetime}]"
           string.concat("[#{::Process.pid}]") if include_pid
@@ -69,8 +69,7 @@ module Legion
         tag
       end
 
-      def build_runner_trace
-        loc = caller_locations(6, 1)&.first
+      def build_runner_trace(loc = caller_locations(6, 1)&.first)
         return unless loc
 
         path = loc.to_s.split('/').last(2)
@@ -94,10 +93,14 @@ module Legion
         if logfile && log_stdout != false
           path = prepare_log_path(logfile)
           require_relative 'multi_io'
-          io = MultiIO.new($stdout, File.open(path, 'a'))
+          file = File.new(path, 'a')
+          file.sync = true
+          io = MultiIO.new($stdout, file)
           @log = ::Logger.new(io)
         elsif logfile
-          @log = ::Logger.new(prepare_log_path(logfile))
+          file = File.new(prepare_log_path(logfile), 'a')
+          file.sync = true
+          @log = ::Logger.new(file)
         else
           @log = ::Logger.new($stdout)
         end
@@ -150,9 +153,9 @@ module Legion
 
       def stop_async_writer
         writer = @async_writer
-        @async_writer = nil
-        @async = false
         writer&.stop
+        @async_writer = nil if @async_writer.equal?(writer)
+        @async = false
       end
     end
   end

--- a/lib/legion/logging/event_builder.rb
+++ b/lib/legion/logging/event_builder.rb
@@ -11,6 +11,29 @@ module Legion
       MAX_PAYLOAD_BYTES        = 8192
       MAX_TOTAL_BYTES          = 65_536
       BACKTRACE_FALLBACK_FRAMES = 20
+      MIN_TRUNCATED_FIELD_BYTES = 256
+
+      CORE_EXCEPTION_FIELDS = %i[
+        timestamp
+        level
+        exception_class
+        message
+        caller_file
+        caller_line
+        caller_function
+        lex
+        component_type
+        gem_name
+        lex_version
+        handled
+        pid
+        thread
+        task_id
+        conversation_id
+        user
+        error_fingerprint
+        node
+      ].freeze
 
       GEM_SPEC_CACHE_MUTEX = Mutex.new
       private_constant :GEM_SPEC_CACHE_MUTEX
@@ -310,6 +333,56 @@ module Legion
           return if safe_json_bytesize(event) <= MAX_TOTAL_BYTES
 
           event[:message] = truncate_bytes(event[:message].to_s, 1024)
+          trim_optional_fields!(event)
+          hard_cap_message!(event)
+        end
+
+        def trim_optional_fields!(event)
+          while safe_json_bytesize(event) > MAX_TOTAL_BYTES
+            key = largest_optional_field(event)
+            break unless key
+
+            reduced = reduce_field(event[key])
+            if reduced.nil?
+              event.delete(key)
+            else
+              event[key] = reduced
+            end
+          end
+        end
+
+        def largest_optional_field(event)
+          event.each_key
+               .reject { |key| CORE_EXCEPTION_FIELDS.include?(key) }
+               .max_by { |key| safe_json_bytesize(event[key]) }
+        end
+
+        def reduce_field(value)
+          case value
+          when String
+            return nil if value.bytesize <= MIN_TRUNCATED_FIELD_BYTES
+
+            truncate_bytes(value, [value.bytesize / 2, MIN_TRUNCATED_FIELD_BYTES].max)
+          when Array
+            return nil if value.size <= 1
+
+            value.first([value.size / 2, 1].max)
+          when Hash
+            return nil if value.size <= 1
+
+            value.first([value.size / 2, 1].max).to_h
+          end
+        end
+
+        def hard_cap_message!(event)
+          return if safe_json_bytesize(event) <= MAX_TOTAL_BYTES
+
+          event[:message] = truncate_bytes(event[:message].to_s, MIN_TRUNCATED_FIELD_BYTES)
+          return if safe_json_bytesize(event) <= MAX_TOTAL_BYTES
+
+          message_overhead = safe_json_bytesize(event.merge(message: ''))
+          available = MAX_TOTAL_BYTES - message_overhead
+          event[:message] = truncate_bytes(event[:message].to_s, [available, 0].max)
         end
       end
     end

--- a/lib/legion/logging/helper.rb
+++ b/lib/legion/logging/helper.rb
@@ -54,7 +54,19 @@ module Legion
       end
 
       def log
-        @log ||= Legion::Logging::TaggedLogger.new(segments: derive_log_segments, **resolve_logger_settings)
+        current_generation =
+          if defined?(Legion::Logging) && Legion::Logging.respond_to?(:configuration_generation)
+            Legion::Logging.configuration_generation
+          else
+            0
+          end
+
+        if !defined?(@log) || @log.nil? || @log_generation != current_generation
+          @log = Legion::Logging::TaggedLogger.new(segments: derive_log_segments, **tagged_logger_settings)
+          @log_generation = current_generation
+        end
+
+        @log
       end
 
       def with_log_context(method_name)
@@ -70,19 +82,13 @@ module Legion
         spec = gem_spec
         ctx = Thread.current[:legion_context] || {}
 
-        event = Legion::Logging::EventBuilder.build_exception(
+        event = build_exception_event(
           exception:       exception,
           level:           level,
-          lex:             log_name,
-          component_type:  derive_component_type,
-          gem_name:        gem_name,
-          lex_version:     spec&.version&.to_s,
-          gem_path:        spec&.full_gem_path,
-          source_code_uri: spec&.metadata&.[]('source_code_uri'),
+          spec:            spec,
           handled:         handled,
           task_id:         task_id || ctx[:task_id],
-          payload_summary: opts.empty? ? nil : opts,
-          caller_offset:   3
+          payload_summary: opts.empty? ? nil : opts
         )
 
         event[:conversation_id] ||= ctx[:conversation_id]
@@ -93,10 +99,56 @@ module Legion
         event = Legion::Logging::Redactor.redact(event) if defined?(Legion::Logging::Redactor)
 
         write_exception_to_log(exception, event, level, segments)
-        publish_exception(event, level)
+        publish_exception(event, level) if structured_exception_support?
       end
 
       private
+
+      def build_exception_event(exception:, level:, spec:, handled:, task_id:, payload_summary:)
+        unless structured_exception_support?
+          return fallback_exception_event(
+            exception:       exception,
+            level:           level,
+            spec:            spec,
+            handled:         handled,
+            task_id:         task_id,
+            payload_summary: payload_summary
+          )
+        end
+
+        Legion::Logging::EventBuilder.build_exception(
+          exception:       exception,
+          level:           level,
+          lex:             log_name,
+          component_type:  derive_component_type,
+          gem_name:        gem_name,
+          lex_version:     spec&.version&.to_s,
+          gem_path:        spec&.full_gem_path,
+          source_code_uri: spec&.metadata&.[]('source_code_uri'),
+          handled:         handled,
+          task_id:         task_id,
+          payload_summary: payload_summary,
+          caller_offset:   3
+        )
+      end
+
+      def fallback_exception_event(exception:, level:, spec:, handled:, task_id:, payload_summary:)
+        {
+          exception_class:   exception.class.to_s,
+          message:           exception.message,
+          level:             level,
+          lex:               log_name,
+          component_type:    derive_component_type,
+          gem_name:          gem_name,
+          lex_version:       spec&.version&.to_s,
+          gem_path:          spec&.full_gem_path,
+          source_code_uri:   spec&.metadata&.[]('source_code_uri'),
+          handled:           handled,
+          task_id:           task_id,
+          payload_summary:   payload_summary,
+          error_fingerprint: SecureRandom.uuid
+        }
+      end
 
       def derive_log_segments
         key = respond_to?(:ancestors) ? ancestors.first : self.class
@@ -167,22 +219,238 @@ module Legion
         @gem_spec_value = nil
       end
 
-      def settings
-        { logger: logger_settings }
+      def instance_log_level(default = Legion::Logging::Settings.default[:level] || :info)
+        component_level = component_log_level
+        return component_level if present_log_level?(component_level)
+
+        global_level = global_log_level
+        return global_level if present_log_level?(global_level)
+
+        Legion::Logging::Settings.default[:level] || default
+      rescue StandardError => e
+        Legion::Logging.warn("Legion::Logging::Helper.instance_log_level(#{default}) failed: #{e.class}: #{e.message}")
+        Legion::Logging::Settings.default[:level] || default
       end
 
-      def logger_settings
-        return Legion::Settings[:logging] if defined?(Legion::Settings) && Legion::Settings[:logging].is_a?(Hash)
+      def global_logger_settings
+        defaults = defined?(Legion::Logging::Settings) ? Legion::Logging::Settings.default.dup : {}
+        settings_logging = if defined?(Legion::Settings) &&
+                              Legion::Settings.respond_to?(:loaded?) &&
+                              Legion::Settings.loaded?
+                             raw = Legion::Settings[:logging]
+                             raw.is_a?(Hash) ? raw : {}
+                           else
+                             {}
+                           end
+        runtime_logging = if defined?(Legion::Logging) &&
+                             Legion::Logging.respond_to?(:current_settings)
+                            current = Legion::Logging.current_settings
+                            current.is_a?(Hash) ? current : {}
+                          else
+                            {}
+                          end
 
-        Legion::Logging::Settings.default
+        defaults.merge(settings_logging).merge(runtime_logging)
       end
 
       def resolve_logger_settings
-        s = settings
-        return Legion::Logging::Settings.default unless s.is_a?(Hash)
+        base = global_logger_settings
+        override = component_logger_settings
+        merged = override ? base.merge(override) : base
+        merged.merge(
+          level:      instance_log_level(merged[:level]),
+          trace:      instance_trace(merged[:trace]),
+          trace_size: instance_trace_size(merged[:trace_size]),
+          extended:   instance_extended(merged[:extended])
+        )
+      rescue StandardError
+        defined?(Legion::Logging::Settings) ? Legion::Logging::Settings.default : {}
+      end
 
-        raw = s[:logger]
-        raw.is_a?(Hash) ? raw : Legion::Logging::Settings.default
+      def tagged_logger_settings
+        settings = resolve_logger_settings
+        {
+          level:      settings[:level],
+          trace:      settings[:trace],
+          trace_size: settings[:trace_size],
+          extended:   settings[:extended]
+        }
+      end
+
+      def component_logger_settings
+        source = component_settings
+        raw = settings_value(source, :logger)
+        raw.is_a?(Hash) ? raw : nil
+      end
+
+      def component_log_level
+        source = component_settings
+        return unless source.is_a?(Hash)
+
+        settings_value(source, :log_level) ||
+          settings_value(source, :logger_level) ||
+          settings_value(source, :logger, :level)
+      end
+
+      def instance_trace(default = Legion::Logging::Settings.default[:trace])
+        component_trace = component_logger_option(:trace)
+        return component_trace unless component_trace.nil?
+
+        global_trace = global_logger_option(:trace)
+        return global_trace unless global_trace.nil?
+
+        Legion::Logging::Settings.default[:trace].nil? ? default : Legion::Logging::Settings.default[:trace]
+      rescue StandardError => e
+        Legion::Logging.warn("Legion::Logging::Helper.instance_trace(#{default}) failed: #{e.class}: #{e.message}")
+        Legion::Logging::Settings.default[:trace].nil? ? default : Legion::Logging::Settings.default[:trace]
+      end
+
+      def instance_trace_size(default = Legion::Logging::Settings.default[:trace_size] || 4)
+        component_trace_size = component_logger_option(:trace_size)
+        return component_trace_size unless component_trace_size.nil?
+
+        global_trace_size = global_logger_option(:trace_size)
+        return global_trace_size unless global_trace_size.nil?
+
+        Legion::Logging::Settings.default[:trace_size] || default
+      rescue StandardError => e
+        Legion::Logging.warn("Legion::Logging::Helper.instance_trace_size(#{default}) failed: #{e.class}: #{e.message}")
+        Legion::Logging::Settings.default[:trace_size] || default
+      end
+
+      def instance_extended(default = Legion::Logging::Settings.default[:extended])
+        component_extended = component_logger_option(:extended)
+        return component_extended unless component_extended.nil?
+
+        global_extended = global_logger_option(:extended)
+        return global_extended unless global_extended.nil?
+
+        Legion::Logging::Settings.default[:extended].nil? ? default : Legion::Logging::Settings.default[:extended]
+      rescue StandardError => e
+        Legion::Logging.warn("Legion::Logging::Helper.instance_extended(#{default}) failed: #{e.class}: #{e.message}")
+        Legion::Logging::Settings.default[:extended].nil? ? default : Legion::Logging::Settings.default[:extended]
+      end
+
+      def component_settings
+        local = local_settings_hash
+        return local if local.is_a?(Hash)
+
+        legion_component_settings
+      end
+
+      def local_settings_hash
+        return unless respond_to?(:settings, true)
+
+        source = settings
+        source if source.is_a?(Hash)
+      rescue StandardError
+        nil
+      end
+
+      def legion_component_settings
+        return unless defined?(Legion::Settings)
+        return unless Legion::Settings.respond_to?(:loaded?) ? Legion::Settings.loaded? : true
+
+        key = derive_component_settings_key
+        return unless key
+
+        top_level = Legion::Settings[key]
+        return top_level if top_level.is_a?(Hash)
+
+        extension_settings = Legion::Settings.dig(:extensions, key)
+        extension_settings if extension_settings.is_a?(Hash)
+      rescue StandardError
+        nil
+      end
+
+      def derive_component_settings_key
+        base = log_name
+        return unless base
+
+        base.to_s.tr('-', '_').to_sym
+      rescue StandardError
+        nil
+      end
+
+      def global_log_level
+        runtime_level = if defined?(Legion::Logging) &&
+                           Legion::Logging.respond_to?(:current_settings)
+                          settings_value(Legion::Logging.current_settings, :level)
+                        end
+        return runtime_level if present_log_level?(runtime_level)
+
+        return unless defined?(Legion::Settings)
+        return unless Legion::Settings.respond_to?(:loaded?) ? Legion::Settings.loaded? : true
+
+        settings_value(Legion::Settings[:logging], :level) || Legion::Settings[:level]
+      rescue StandardError
+        nil
+      end
+
+      def component_logger_option(key)
+        source = component_settings
+        return unless source.is_a?(Hash)
+
+        return settings_value(source, key) if settings_key?(source, key)
+        return settings_value(source, :logger, key) if settings_key?(source, :logger, key)
+
+        nil
+      end
+
+      def global_logger_option(key)
+        runtime_value = if defined?(Legion::Logging) &&
+                           Legion::Logging.respond_to?(:current_settings)
+                          settings_value(Legion::Logging.current_settings, key)
+                        end
+        return runtime_value unless runtime_value.nil?
+
+        return unless defined?(Legion::Settings)
+        return unless Legion::Settings.respond_to?(:loaded?) ? Legion::Settings.loaded? : true
+
+        settings_value(Legion::Settings[:logging], key)
+      rescue StandardError
+        nil
+      end
+
+      def settings_value(source, *keys)
+        missing = Object.new
+        current = source
+        keys.each do |key|
+          current =
+            if current.is_a?(Hash) && current.key?(key)
+              current[key]
+            elsif current.is_a?(Hash) && current.key?(key.to_s)
+              current[key.to_s]
+            else
+              missing
+            end
+
+          break if current.equal?(missing)
+        end
+
+        current.equal?(missing) ? nil : current
+      end
+
+      def settings_key?(source, *keys)
+        current = source
+        keys.each do |key|
+          return false unless current.is_a?(Hash)
+
+          next_key = if current.key?(key)
+                       key
+                     elsif current.key?(key.to_s)
+                       key.to_s
+                     else
+                       return false
+                     end
+          current = current[next_key]
+        end
+
+        true
+      end
+
+      def present_log_level?(value)
+        !value.nil? && !(value.respond_to?(:empty?) && value.empty?)
       end
 
       # -- Exception stdout/file output --
@@ -193,9 +461,14 @@ module Legion
 
         message = format_exception_output(exception, event)
         message = Legion::Logging::Redactor.redact_string(message) if defined?(Legion::Logging::Redactor) && redaction_enabled?
-        message = colorize_exception(message, level) if Legion::Logging.color
+        message = colorize_exception(message, level) if Legion::Logging.respond_to?(:color) && Legion::Logging.color
 
-        Legion::Logging.log.public_send(level, message)
+        logger = Legion::Logging.respond_to?(:log) ? Legion::Logging.log : nil
+        if logger.respond_to?(level)
+          logger.public_send(level, message)
+        elsif Legion::Logging.respond_to?(level)
+          Legion::Logging.public_send(level, message)
+        end
       ensure
         Thread.current[:legion_log_segments] = prev_segs
       end
@@ -251,6 +524,8 @@ module Legion
       # -- Exception structured publish --
 
       def publish_exception(event, level)
+        return unless structured_exception_support?
+
         lex_name = event[:lex] || 'core'
         comp = event[:component_type] || :unknown
         routing_key = "legion.logging.exception.#{level}.#{lex_name}.#{comp}"
@@ -260,7 +535,12 @@ module Legion
 
         Legion::Logging.exception_writer.call(event, routing_key: routing_key, headers: headers, properties: properties)
       rescue StandardError => e
-        Legion::Logging.warn("Failed to publish exception event: #{e.class}: #{e.message}")
+        Legion::Logging.warn("Failed to publish exception event: #{e.class}: #{e.message}") if Legion::Logging.respond_to?(:warn)
+      end
+
+      def structured_exception_support?
+        defined?(Legion::Logging::EventBuilder) &&
+          Legion::Logging.respond_to?(:exception_writer)
       end
 
       def build_exception_headers(event, comp, level)

--- a/lib/legion/logging/methods.rb
+++ b/lib/legion/logging/methods.rb
@@ -131,6 +131,20 @@ module Legion
         end
       end
 
+      def emit_tagged(level, message = nil, segments: nil, method_ctx: nil)
+        level = level.to_sym
+        message = yield if message.nil? && block_given?
+        return if message.nil?
+
+        raw = maybe_redact(message)
+        formatted = format_message_for_level(level, raw)
+
+        with_tagged_context(segments, method_ctx) do
+          write_forced(level, formatted)
+          fire_log_writer(level, raw) if %i[warn error fatal].include?(level)
+        end
+      end
+
       def runner_exception(exc, **opts)
         log_exception(exc, handled: true, **opts)
         { success: false, message: exc.message, backtrace: exc.backtrace }.merge(opts)
@@ -193,6 +207,48 @@ module Legion
         Legion::Logging::Redactor.redact_string(message)
       rescue StandardError
         message
+      end
+
+      def format_message_for_level(level, message)
+        return Rainbow(message).blue if level == :debug && @color
+        return Rainbow(message).green if level == :info && @color
+        return Rainbow(message).yellow if level == :warn && @color
+        return Rainbow(message).red if level == :error && @color
+        return Rainbow(message).darkred if level == :fatal && @color
+        return Rainbow(message).purple if level == :unknown && @color
+
+        message
+      end
+
+      def with_tagged_context(segments, method_ctx)
+        prev_segments = Thread.current[:legion_log_segments]
+        prev_method_ctx = Thread.current[:legion_log_method]
+
+        Thread.current[:legion_log_segments] = segments unless segments.nil?
+        Thread.current[:legion_log_method] = method_ctx unless method_ctx.nil?
+        yield
+      ensure
+        Thread.current[:legion_log_segments] = prev_segments
+        Thread.current[:legion_log_method] = prev_method_ctx
+      end
+
+      def write_forced(level, message)
+        logger = log
+        formatter = logger.formatter || ::Logger::Formatter.new
+        rendered = formatter.call(severity_label_for(level), Time.now, nil, message)
+
+        log_device = logger.instance_variable_get(:@logdev)
+        if log_device.respond_to?(:write)
+          log_device.write(rendered)
+        else
+          $stdout.write(rendered)
+        end
+      end
+
+      def severity_label_for(level)
+        return 'ANY' if level == :unknown
+
+        level.to_s.upcase
       end
 
       def redaction_enabled?

--- a/lib/legion/logging/methods.rb
+++ b/lib/legion/logging/methods.rb
@@ -30,78 +30,36 @@ module Legion
         return unless log.level < 1
 
         message = yield if message.nil? && block_given?
-        message = maybe_redact(message)
-        message = Rainbow(message).blue if @color
-        writer = @async_writer
-        if writer&.alive?
-          writer.push(AsyncWriter::LogEntry.new(
-                        level: :debug, message: message, writer_context: nil,
-                        segments: Thread.current[:legion_log_segments],
-                        method_ctx: Thread.current[:legion_log_method]
-                      ))
-        else
-          log.debug(message)
-        end
+        raw = maybe_redact(message)
+        formatted = format_message_for_level(:debug, raw)
+        write_async_or_sync(:debug, formatted, raw)
       end
 
       def info(message = nil)
         return unless log.level < 2
 
         message = yield if message.nil? && block_given?
-        message = maybe_redact(message)
-        message = Rainbow(message).green if @color
-        writer = @async_writer
-        if writer&.alive?
-          writer.push(AsyncWriter::LogEntry.new(
-                        level: :info, message: message, writer_context: nil,
-                        segments: Thread.current[:legion_log_segments],
-                        method_ctx: Thread.current[:legion_log_method]
-                      ))
-        else
-          log.info(message)
-        end
+        raw = maybe_redact(message)
+        formatted = format_message_for_level(:info, raw)
+        write_async_or_sync(:info, formatted, raw)
       end
 
       def warn(message = nil)
         return unless log.level < 3
 
         message = yield if message.nil? && block_given?
-        message = maybe_redact(message)
-        raw = message
-        message = Rainbow(message).yellow if @color
-        writer = @async_writer
-        if writer&.alive?
-          ctx = build_writer_context(:warn, raw)
-          writer.push(AsyncWriter::LogEntry.new(
-                        level: :warn, message: message, writer_context: ctx,
-                        segments: Thread.current[:legion_log_segments],
-                        method_ctx: Thread.current[:legion_log_method]
-                      ))
-        else
-          log.warn(message)
-          fire_log_writer(:warn, raw)
-        end
+        raw = maybe_redact(message)
+        formatted = format_message_for_level(:warn, raw)
+        write_async_or_sync(:warn, formatted, raw, writer_context: build_writer_context(:warn, raw))
       end
 
       def error(message = nil)
         return unless log.level < 4
 
         message = yield if message.nil? && block_given?
-        message = maybe_redact(message)
-        raw = message
-        message = Rainbow(message).red if @color
-        writer = @async_writer
-        if writer&.alive?
-          ctx = build_writer_context(:error, raw)
-          writer.push(AsyncWriter::LogEntry.new(
-                        level: :error, message: message, writer_context: ctx,
-                        segments: Thread.current[:legion_log_segments],
-                        method_ctx: Thread.current[:legion_log_method]
-                      ))
-        else
-          log.error(message)
-          fire_log_writer(:error, raw)
-        end
+        raw = maybe_redact(message)
+        formatted = format_message_for_level(:error, raw)
+        write_async_or_sync(:error, formatted, raw, writer_context: build_writer_context(:error, raw))
       end
 
       def fatal(message = nil)
@@ -117,18 +75,9 @@ module Legion
 
       def unknown(message = nil)
         message = yield if message.nil? && block_given?
-        message = maybe_redact(message)
-        message = Rainbow(message).purple if @color
-        writer = @async_writer
-        if writer&.alive?
-          writer.push(AsyncWriter::LogEntry.new(
-                        level: :unknown, message: message, writer_context: nil,
-                        segments: Thread.current[:legion_log_segments],
-                        method_ctx: Thread.current[:legion_log_method]
-                      ))
-        else
-          log.unknown(message)
-        end
+        raw = maybe_redact(message)
+        formatted = format_message_for_level(:unknown, raw)
+        write_async_or_sync(:unknown, formatted, raw)
       end
 
       def emit_tagged(level, message = nil, segments: nil, method_ctx: nil)
@@ -157,6 +106,7 @@ module Legion
         level = level.to_sym if level.respond_to?(:to_sym)
         # 1. Log human-readable line to stdout/file (bypass writer callbacks)
         msg = exception.respond_to?(:message) ? exception.message : exception.to_s
+        msg = maybe_redact(msg)
         log.public_send(level, msg) if respond_to?(:log) && log.respond_to?(level)
 
         # 2. Build rich exception event
@@ -249,6 +199,39 @@ module Legion
         return 'ANY' if level == :unknown
 
         level.to_s.upcase
+      end
+
+      def write_async_or_sync(level, formatted_message, raw_message, writer_context: nil)
+        writer = @async_writer
+        caller_trace = capture_runner_trace_for_async
+        if writer&.alive?
+          queued = writer.push(AsyncWriter::LogEntry.new(
+                                 level:          level,
+                                 message:        formatted_message,
+                                 writer_context: writer_context,
+                                 segments:       Thread.current[:legion_log_segments],
+                                 method_ctx:     Thread.current[:legion_log_method],
+                                 caller_trace:   caller_trace
+                               ))
+          return if queued
+        end
+
+        with_caller_trace(caller_trace) do
+          log.public_send(level, formatted_message)
+          fire_log_writer(level, raw_message) if writer_context
+        end
+      end
+
+      def capture_runner_trace_for_async
+        build_runner_trace(caller_locations(4, 1)&.first)
+      end
+
+      def with_caller_trace(caller_trace)
+        prev_caller_trace = Thread.current[:legion_log_caller]
+        Thread.current[:legion_log_caller] = caller_trace
+        yield
+      ensure
+        Thread.current[:legion_log_caller] = prev_caller_trace
       end
 
       def redaction_enabled?

--- a/lib/legion/logging/multi_io.rb
+++ b/lib/legion/logging/multi_io.rb
@@ -10,7 +10,6 @@ module Legion
       def write(message)
         @targets.each do |t|
           t.write(message)
-          t.flush if t.respond_to?(:flush)
         end
       end
 

--- a/lib/legion/logging/redactor.rb
+++ b/lib/legion/logging/redactor.rb
@@ -18,7 +18,18 @@ module Legion
         bearer_token:   %r{Bearer\s+[A-Za-z0-9._~+/=-]{20,}}i
       }.freeze
 
-      SENSITIVE_FIELDS = %w[password secret token api_key authorization].freeze
+      SENSITIVE_FIELDS = %w[
+        password
+        secret
+        token
+        api_key
+        access_key
+        private_key
+        public_key
+        authorization
+      ].freeze
+      SENSITIVE_SUFFIXES = %w[token secret password passphrase credential credentials].freeze
+      SAFE_KEY_FIELDS = %w[primary_key foreign_key sort_key partition_key routing_key].freeze
 
       REDACTED = '[REDACTED]'
 
@@ -49,7 +60,17 @@ module Legion
         private
 
         def sensitive_field?(key)
-          SENSITIVE_FIELDS.include?(key.to_s.downcase)
+          normalized = normalize_key(key)
+          return false if SAFE_KEY_FIELDS.include?(normalized)
+          return true if SENSITIVE_FIELDS.include?(normalized)
+          return true if normalized.include?('authorization')
+          return true if normalized.start_with?('auth_') || normalized.end_with?('_auth')
+          return true if normalized.start_with?('bearer_') || normalized.end_with?('_bearer')
+          return true if SENSITIVE_SUFFIXES.any? { |suffix| normalized.end_with?("_#{suffix}") }
+
+          %w[api access client private public auth secret signing session].any? do |prefix|
+            normalized == "#{prefix}_key"
+          end
         end
 
         def all_patterns
@@ -78,6 +99,16 @@ module Legion
 
         def reset_pattern_cache!
           @all_patterns = nil
+        end
+
+        def refresh_patterns!
+          reset_pattern_cache!
+        end
+
+        public :refresh_patterns!
+
+        def normalize_key(key)
+          key.to_s.downcase.gsub(/[^a-z0-9]+/, '_').gsub(/\A_+|_+\z/, '')
         end
       end
     end

--- a/lib/legion/logging/settings.rb
+++ b/lib/legion/logging/settings.rb
@@ -6,9 +6,9 @@ module Legion
       def self.default
         {
           level:      :info,
-          trace:      false,
+          trace:      true,
           trace_size: 4,
-          extended:   false
+          extended:   true
         }
       end
     end

--- a/lib/legion/logging/shipper.rb
+++ b/lib/legion/logging/shipper.rb
@@ -30,21 +30,25 @@ module Legion
           transport = TRANSPORTS[transport_type]
           return unless transport
 
-          batch = nil
-          @mutex.synchronize do
-            batch = @buffer.dup
-            @buffer.clear
-          end
+          @flush_mutex ||= Mutex.new
+          @flush_mutex.synchronize do
+            batch = nil
+            @mutex.synchronize { batch = @buffer.dup }
+            return if batch.empty?
 
-          deliver(transport, batch)
+            delivered = deliver(transport, batch)
+            @mutex.synchronize { @buffer.shift(batch.size) if delivered }
+            delivered
+          end
         end
 
         def start
           return unless enabled?
           return if @flush_thread&.alive?
 
-          @buffer = []
-          @mutex  = Mutex.new
+          @buffer ||= []
+          @mutex  ||= Mutex.new
+          @flush_mutex ||= Mutex.new
           interval = flush_interval
           @flush_thread = Thread.new do
             loop do
@@ -83,14 +87,14 @@ module Legion
         end
 
         def deliver(transport, batch)
-          if transport.method(:ship).arity == 1
-            # HttpTransport accepts a batch array
-            transport.ship(batch)
+          if transport.respond_to?(:ship_batch)
+            transport.ship_batch(batch)
           else
-            batch.each { |e| transport.ship(e) }
+            batch.all? { |event| transport.ship(event) }
           end
         rescue StandardError => e
           Legion::Logging.error("Shipper deliver failed: #{e.message}") if defined?(Legion::Logging)
+          false
         end
 
         def shippable_level?(level)

--- a/lib/legion/logging/shipper/file_transport.rb
+++ b/lib/legion/logging/shipper/file_transport.rb
@@ -11,10 +11,18 @@ module Legion
 
         class << self
           def ship(event)
+            ship_batch([event])
+          end
+
+          def ship_batch(events)
+            batch = Array(events)
+            return true if batch.empty?
+
             path = resolve_path
             FileUtils.mkdir_p(File.dirname(path))
             File.open(path, 'a') do |f|
-              f.puts(::JSON.generate(event))
+              f.write(batch.map { |event| ::JSON.generate(event) }.join("\n"))
+              f.write("\n")
             end
             true
           rescue StandardError => e

--- a/lib/legion/logging/shipper/http_transport.rb
+++ b/lib/legion/logging/shipper/http_transport.rb
@@ -10,6 +10,10 @@ module Legion
       module HttpTransport
         class << self
           def ship(events)
+            ship_batch(events)
+          end
+
+          def ship_batch(events)
             endpoint = resolve_endpoint
             return false unless endpoint
 

--- a/lib/legion/logging/tagged_logger.rb
+++ b/lib/legion/logging/tagged_logger.rb
@@ -7,13 +7,21 @@ module Legion
 
       attr_reader :segments, :trace_enabled, :extended
 
-      def initialize(segments:, level: :error, trace: true, trace_size: 4, extended: true, **_opts)
+      def initialize(
+        segments:,
+        level: Legion::Logging::Settings.default[:level],
+        trace: Legion::Logging::Settings.default[:trace],
+        trace_size: Legion::Logging::Settings.default[:trace_size],
+        extended: Legion::Logging::Settings.default[:extended],
+        **_opts
+      )
         @segments = segments
         @level_value =
           if level.is_a?(Integer)
             level
           else
-            LEVELS.fetch(level.to_s.downcase.to_sym, LEVELS[:debug])
+            default_level = Legion::Logging::Settings.default[:level].to_s.downcase.to_sym
+            LEVELS.fetch(level.to_s.downcase.to_sym, LEVELS.fetch(default_level, LEVELS[:info]))
           end
         @trace_enabled = trace
         @trace_size = trace_size

--- a/lib/legion/logging/tagged_logger.rb
+++ b/lib/legion/logging/tagged_logger.rb
@@ -7,13 +7,13 @@ module Legion
 
       attr_reader :segments, :trace_enabled, :extended
 
-      def initialize(segments:, level: :info, trace: false, trace_size: 4, extended: false, **_opts)
+      def initialize(segments:, level: :error, trace: true, trace_size: 4, extended: true, **_opts)
         @segments = segments
         @level_value =
           if level.is_a?(Integer)
             level
           else
-            LEVELS.fetch(level.to_s.downcase.to_sym, LEVELS[:info])
+            LEVELS.fetch(level.to_s.downcase.to_sym, LEVELS[:debug])
           end
         @trace_enabled = trace
         @trace_size = trace_size
@@ -28,40 +28,40 @@ module Legion
         return unless @level_value < 1
 
         message = yield if message.nil? && block_given?
-        with_segments { Legion::Logging.debug(message) }
+        with_segments { dispatch(:debug, message) }
       end
 
       def info(message = nil)
         return unless @level_value < 2
 
         message = yield if message.nil? && block_given?
-        with_segments { Legion::Logging.info(message) }
+        with_segments { dispatch(:info, message) }
       end
 
       def warn(message = nil)
         return unless @level_value < 3
 
         message = yield if message.nil? && block_given?
-        with_segments { Legion::Logging.warn(message) }
+        with_segments { dispatch(:warn, message) }
       end
 
       def error(message = nil)
         return unless @level_value < 4
 
         message = yield if message.nil? && block_given?
-        with_segments { Legion::Logging.error(message) }
+        with_segments { dispatch(:error, message) }
       end
 
       def fatal(message = nil)
         return unless @level_value < 5
 
         message = yield if message.nil? && block_given?
-        with_segments { Legion::Logging.fatal(message) }
+        with_segments { dispatch(:fatal, message) }
       end
 
       def unknown(message = nil)
         message = yield if message.nil? && block_given?
-        with_segments { Legion::Logging.unknown(message) }
+        with_segments { dispatch(:unknown, message) }
       end
 
       def trace(raw_message = nil, size: @trace_size, log_caller: true)
@@ -85,6 +85,29 @@ module Legion
       end
 
       private
+
+      def dispatch(level, message)
+        return unless defined?(Legion::Logging)
+
+        if Legion::Logging.respond_to?(:emit_tagged)
+          Legion::Logging.emit_tagged(level, message, segments: @segments)
+          return
+        end
+
+        if Legion::Logging.respond_to?(level)
+          Legion::Logging.public_send(level, message)
+          return
+        end
+
+        fallback = fallback_level(level)
+        Legion::Logging.public_send(fallback, message) if fallback && Legion::Logging.respond_to?(fallback)
+      end
+
+      def fallback_level(level)
+        return :debug if level == :unknown
+
+        nil
+      end
 
       def with_segments
         prev = Thread.current[:legion_log_segments]

--- a/lib/legion/logging/version.rb
+++ b/lib/legion/logging/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Logging
-    VERSION = '1.4.3'
+    VERSION = '1.5.0'
   end
 end

--- a/spec/legion/logging/async_writer_spec.rb
+++ b/spec/legion/logging/async_writer_spec.rb
@@ -33,6 +33,38 @@ RSpec.describe Legion::Logging::AsyncWriter do
       subject.start
       expect(subject.instance_variable_get(:@thread)).to equal(thread)
     end
+
+    it 'times out instead of deadlocking when shutdown cannot finish promptly' do
+      gate = Queue.new
+      slow_writer_class = Class.new(described_class) do
+        def initialize(logger, gate:, **)
+          @gate = gate
+          super(logger, **)
+        end
+
+        private
+
+        def consume
+          @gate.pop
+          super
+        end
+      end
+
+      writer = slow_writer_class.new(logger, gate: gate, buffer_size: 1)
+      writer.start
+      writer.push(Legion::Logging::AsyncWriter::LogEntry.new(
+                    level: :info, message: 'blocked', writer_context: nil, segments: nil, method_ctx: nil,
+                    caller_trace: nil
+                  ))
+
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      expect(writer.stop(timeout: 0.01)).to be(false)
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+      expect(elapsed).to be < 0.2
+
+      gate << true
+      expect(writer.stop(timeout: 1)).to be(true)
+    end
   end
 
   describe '#push' do
@@ -233,7 +265,13 @@ RSpec.describe 'async routing through Methods' do
   end
 
   it 'falls back to sync when the async writer rejects a queued entry' do
-    writer = instance_double(Legion::Logging::AsyncWriter, alive?: true, push: false, stop: true)
+    writer = instance_double(
+      Legion::Logging::AsyncWriter,
+      alive?: true,
+      push:   false,
+      stop:   true,
+      logger: Legion::Logging.log
+    )
     Legion::Logging.instance_variable_set(:@async_writer, writer)
     Legion::Logging.instance_variable_set(:@async, true)
 

--- a/spec/legion/logging/async_writer_spec.rb
+++ b/spec/legion/logging/async_writer_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'legion/logging/async_writer'
+require 'tmpdir'
 
 RSpec.describe Legion::Logging::AsyncWriter do
   let(:logger) { Logger.new($stdout) }
@@ -41,7 +42,7 @@ RSpec.describe Legion::Logging::AsyncWriter do
 
     it 'writes entries to the logger' do
       entry = Legion::Logging::AsyncWriter::LogEntry.new(
-        level: :info, message: 'async test', writer_context: nil, segments: nil, method_ctx: nil
+        level: :info, message: 'async test', writer_context: nil, segments: nil, method_ctx: nil, caller_trace: nil
       )
       subject.push(entry)
       subject.stop
@@ -51,10 +52,35 @@ RSpec.describe Legion::Logging::AsyncWriter do
       messages = []
       allow(logger).to receive(:info) { |msg| messages << msg }
 
-      3.times { |i| subject.push(Legion::Logging::AsyncWriter::LogEntry.new(level: :info, message: "msg-#{i}", writer_context: nil, segments: nil, method_ctx: nil)) }
+      3.times do |i|
+        subject.push(Legion::Logging::AsyncWriter::LogEntry.new(
+                       level: :info, message: "msg-#{i}", writer_context: nil, segments: nil, method_ctx: nil,
+                       caller_trace: nil
+                     ))
+      end
       subject.stop
 
       expect(messages).to eq(%w[msg-0 msg-1 msg-2])
+    end
+
+    it 'waits for an in-flight entry to finish on stop' do
+      write_started = Queue.new
+      messages = []
+      allow(logger).to receive(:info) do |msg|
+        write_started << true
+        sleep 0.05
+        messages << msg
+      end
+
+      entry = Legion::Logging::AsyncWriter::LogEntry.new(
+        level: :info, message: 'slow message', writer_context: nil, segments: nil, method_ctx: nil, caller_trace: nil
+      )
+
+      subject.push(entry)
+      write_started.pop
+      subject.stop
+
+      expect(messages).to eq(['slow message'])
     end
   end
 
@@ -62,11 +88,19 @@ RSpec.describe Legion::Logging::AsyncWriter do
     subject { described_class.new(logger, buffer_size: 2) }
 
     it 'blocks the caller when the queue is full' do
-      2.times { |i| subject.push(Legion::Logging::AsyncWriter::LogEntry.new(level: :info, message: "fill-#{i}", writer_context: nil, segments: nil, method_ctx: nil)) }
+      2.times do |i|
+        subject.push(Legion::Logging::AsyncWriter::LogEntry.new(
+                       level: :info, message: "fill-#{i}", writer_context: nil, segments: nil, method_ctx: nil,
+                       caller_trace: nil
+                     ))
+      end
 
       blocked = true
       pusher = Thread.new do
-        subject.push(Legion::Logging::AsyncWriter::LogEntry.new(level: :info, message: 'overflow', writer_context: nil, segments: nil, method_ctx: nil))
+        subject.push(Legion::Logging::AsyncWriter::LogEntry.new(
+                       level: :info, message: 'overflow', writer_context: nil, segments: nil, method_ctx: nil,
+                       caller_trace: nil
+                     ))
         blocked = false
       end
 
@@ -86,7 +120,12 @@ RSpec.describe Legion::Logging::AsyncWriter do
       allow(logger).to receive(:warn) { |msg| messages << msg }
 
       subject.start
-      5.times { |i| subject.push(Legion::Logging::AsyncWriter::LogEntry.new(level: :warn, message: "drain-#{i}", writer_context: nil, segments: nil, method_ctx: nil)) }
+      5.times do |i|
+        subject.push(Legion::Logging::AsyncWriter::LogEntry.new(
+                       level: :warn, message: "drain-#{i}", writer_context: nil, segments: nil, method_ctx: nil,
+                       caller_trace: nil
+                     ))
+      end
       subject.stop
 
       expect(messages).to eq((0..4).map { |i| "drain-#{i}" })
@@ -108,7 +147,7 @@ RSpec.describe Legion::Logging::AsyncWriter do
       entry = Legion::Logging::AsyncWriter::LogEntry.new(
         level: :error, message: 'writer test',
         writer_context: { level: :error, event: event },
-        segments: nil, method_ctx: nil
+        segments: nil, method_ctx: nil, caller_trace: nil
       )
       subject.push(entry)
       deadline = Time.now + 2
@@ -124,7 +163,9 @@ RSpec.describe Legion::Logging::AsyncWriter do
     subject { described_class.new(logger) }
 
     it 'is a frozen Data struct' do
-      entry = Legion::Logging::AsyncWriter::LogEntry.new(level: :info, message: 'test', writer_context: nil, segments: nil, method_ctx: nil)
+      entry = Legion::Logging::AsyncWriter::LogEntry.new(
+        level: :info, message: 'test', writer_context: nil, segments: nil, method_ctx: nil, caller_trace: nil
+      )
       expect(entry).to be_frozen
     end
   end
@@ -144,18 +185,33 @@ RSpec.describe 'Legion::Logging::Logger instance async' do
 end
 
 RSpec.describe 'async routing through Methods' do
+  def emit_info_from_spec(message)
+    Legion::Logging.info(message)
+  end
+
   before do
     Legion::Logging.setup(level: 'debug', async: true)
   end
 
   after do
     Legion::Logging.stop_async_writer
+    Legion::Logging.instance_variable_set(:@async_writer, nil)
+    Legion::Logging.instance_variable_set(:@async, false)
   end
 
   it 'routes info through the async writer' do
     writer = Legion::Logging.instance_variable_get(:@async_writer)
     expect(writer).to receive(:push).once
     Legion::Logging.info('async info')
+  end
+
+  it 'captures caller metadata on the producer thread before queueing' do
+    writer = Legion::Logging.instance_variable_get(:@async_writer)
+    expect(writer).to receive(:push) do |entry|
+      expect(entry.caller_trace).to include(file: 'async_writer_spec')
+    end
+
+    emit_info_from_spec('async caller trace')
   end
 
   it 'routes warn through the async writer with writer context' do
@@ -174,5 +230,52 @@ RSpec.describe 'async routing through Methods' do
     Legion::Logging.stop_async_writer
     expect(Legion::Logging.log).to receive(:debug).with(anything)
     Legion::Logging.debug('sync fallback')
+  end
+
+  it 'falls back to sync when the async writer rejects a queued entry' do
+    writer = instance_double(Legion::Logging::AsyncWriter, alive?: true, push: false, stop: true)
+    Legion::Logging.instance_variable_set(:@async_writer, writer)
+    Legion::Logging.instance_variable_set(:@async, true)
+
+    expect(Legion::Logging.log).to receive(:info).with('sync fallback after reject')
+    Legion::Logging.info('sync fallback after reject')
+  end
+end
+
+RSpec.describe 'extended caller metadata under async logging' do
+  let(:tmpdir) { Dir.mktmpdir('legion-logging-extended') }
+  let(:sync_path) { File.join(tmpdir, 'sync.log') }
+  let(:async_path) { File.join(tmpdir, 'async.log') }
+
+  def emit_extended_probe(logger)
+    logger.info('extended metadata probe')
+  end
+
+  def extract_trace(path)
+    match = File.read(path).match(/\[(?<type>[^:\]]+):(?<file>[^:\]]+):(?<function>[^:\]]+):(?<line>\d+)\]/)
+    match&.named_captures
+  end
+
+  after do
+    FileUtils.rm_rf(tmpdir)
+  end
+
+  it 'preserves the same extended caller trace in sync and async modes' do
+    sync_logger = Legion::Logging::Logger.new(
+      level: 'info', lex: 'eval', log_file: sync_path, log_stdout: false, async: false, extended: true
+    )
+    async_logger = Legion::Logging::Logger.new(
+      level: 'info', lex: 'eval', log_file: async_path, log_stdout: false, async: true, extended: true
+    )
+
+    emit_extended_probe(sync_logger)
+    emit_extended_probe(async_logger)
+    async_logger.stop_async_writer
+
+    sync_trace = extract_trace(sync_path)
+    async_trace = extract_trace(async_path)
+
+    expect(async_trace).to include('file' => 'async_writer_spec')
+    expect(async_trace.except('line')).to eq(sync_trace.except('line'))
   end
 end

--- a/spec/legion/logging/builder_spec.rb
+++ b/spec/legion/logging/builder_spec.rb
@@ -45,5 +45,16 @@ RSpec.describe Legion::Logging::Builder do
       Legion::Logging.setup(level: 'info')
       expect(Legion::Logging.async?).to be true
     end
+
+    it 'supports boolean logging.async settings without probing for buffer_size' do
+      stub_const('Legion::Settings', Module.new do
+        def self.[](_key)
+          { async: true }
+        end
+      end)
+
+      expect { Legion::Logging.setup(level: 'info', async: true) }.not_to raise_error
+      expect(Legion::Logging.async?).to be true
+    end
   end
 end

--- a/spec/legion/logging/builder_spec.rb
+++ b/spec/legion/logging/builder_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'tmpdir'
 
 RSpec.describe Legion::Logging::Builder do
   describe '#text_format with lex_segments:' do
@@ -55,6 +56,20 @@ RSpec.describe Legion::Logging::Builder do
 
       expect { Legion::Logging.setup(level: 'info', async: true) }.not_to raise_error
       expect(Legion::Logging.async?).to be true
+    end
+
+    it 'closes the previous file log device when setup replaces it' do
+      Dir.mktmpdir do |dir|
+        first_path = File.join(dir, 'first.log')
+        second_path = File.join(dir, 'second.log')
+
+        Legion::Logging.setup(level: 'info', log_file: first_path, log_stdout: false, async: false)
+        first_device = Legion::Logging.log.instance_variable_get(:@logdev).dev
+
+        Legion::Logging.setup(level: 'info', log_file: second_path, log_stdout: false, async: false)
+
+        expect(first_device.closed?).to be(true)
+      end
     end
   end
 end

--- a/spec/legion/logging/event_builder_spec.rb
+++ b/spec/legion/logging/event_builder_spec.rb
@@ -272,6 +272,30 @@ RSpec.describe Legion::Logging::EventBuilder do
                                               payload_summary: large_payload)
       expect(event[:payload_summary].bytesize).to be <= Legion::Logging::EventBuilder::MAX_PAYLOAD_BYTES
     end
+
+    it 'enforces the total size cap when arbitrary extra fields are huge' do
+      event = described_class.build_exception(
+        exception:  exception,
+        level:      :error,
+        extra_blob: { huge: 'z' * 200_000 },
+        extra_note: 'n' * 20_000
+      )
+
+      expect(JSON.generate(event).bytesize).to be <= described_class::MAX_TOTAL_BYTES
+    end
+
+    it 'retains core exception fields while trimming oversized optional fields' do
+      event = described_class.build_exception(
+        exception:  exception,
+        level:      :error,
+        extra_blob: { huge: 'z' * 200_000 }
+      )
+
+      expect(event[:exception_class]).to eq('RuntimeError')
+      expect(event[:message]).to be_a(String)
+      expect(event[:error_fingerprint]).to match(/\A[0-9a-f]{32}\z/)
+      expect(JSON.generate(event).bytesize).to be <= described_class::MAX_TOTAL_BYTES
+    end
   end
 
   describe '.fingerprint' do

--- a/spec/legion/logging/helper_spec.rb
+++ b/spec/legion/logging/helper_spec.rb
@@ -29,9 +29,80 @@ RSpec.describe Legion::Logging::Helper do
     end
   end
 
+  let(:component_level_class) do
+    Class.new do
+      include Legion::Logging::Helper
+
+      def settings
+        { log_level: 'warn', logger: { level: 'error', trace: true, extended: true } }
+      end
+    end
+  end
+
+  let(:legacy_component_level_class) do
+    Class.new do
+      include Legion::Logging::Helper
+
+      def settings
+        { logger_level: 'info', logger: { trace: true, extended: true } }
+      end
+    end
+  end
+
+  let(:component_options_class) do
+    Class.new do
+      include Legion::Logging::Helper
+
+      def settings
+        { trace: false, trace_size: 7, extended: false, logger: { trace: true, trace_size: 2, extended: true } }
+      end
+    end
+  end
+
+  let(:transport_class) do
+    stub_const('Legion::Transport::HelperProbe', Class.new do
+      include Legion::Logging::Helper
+    end)
+  end
+
+  let(:extension_settings_helper_class) do
+    stub_const('Legion::Extensions::MicrosoftTeams::Transport::Probe', Class.new do
+      include Legion::Logging::Helper
+
+      def lex_filename
+        'microsoft_teams'
+      end
+
+      def settings
+        {}
+      end
+    end)
+  end
+
   describe '#log' do
+    before do
+      Legion::Logging.setup(level: 'debug', async: false, color: false)
+    end
+
     it 'returns a TaggedLogger' do
       expect(bare_class.new.log).to be_a(Legion::Logging::TaggedLogger)
+    end
+
+    it 'passes only tagged-logger supported options to TaggedLogger' do
+      fake_logger = instance_double(
+        Legion::Logging::TaggedLogger,
+        segments:      %w[my_extension runners foo],
+        level:         0,
+        extended:      true,
+        trace_enabled: true
+      )
+
+      expect(Legion::Logging::TaggedLogger).to receive(:new) do |**kwargs|
+        expect(kwargs.keys).to contain_exactly(:segments, :level, :trace, :trace_size, :extended)
+        fake_logger
+      end
+
+      expect(bare_class.new.log).to eq(fake_logger)
     end
 
     it 'derives segments from class namespace' do
@@ -41,9 +112,10 @@ RSpec.describe Legion::Logging::Helper do
 
     it 'uses default settings when no override is defined' do
       logger = bare_class.new.log
-      expect(logger.level).to eq(1)
-      expect(logger.extended).to be false
-      expect(logger.trace_enabled).to be false
+      runtime = Legion::Logging.current_settings
+      expect(logger.level).to eq(Legion::Logging::TaggedLogger::LEVELS.fetch(runtime[:level].to_sym))
+      expect(logger.extended).to be(runtime[:extended])
+      expect(logger.trace_enabled).to be(runtime[:trace])
     end
 
     it 'uses overridden settings when defined' do
@@ -53,10 +125,178 @@ RSpec.describe Legion::Logging::Helper do
       expect(logger.trace_enabled).to be true
     end
 
+    it 'uses a component log_level from the local settings hash' do
+      logger = component_level_class.new.log
+      expect(logger.level).to eq(Legion::Logging::TaggedLogger::LEVELS[:warn])
+      expect(logger.extended).to be true
+      expect(logger.trace_enabled).to be true
+    end
+
+    it 'supports legacy component logger_level settings' do
+      logger = legacy_component_level_class.new.log
+      expect(logger.level).to eq(Legion::Logging::TaggedLogger::LEVELS[:info])
+      expect(logger.extended).to be true
+      expect(logger.trace_enabled).to be true
+    end
+
+    it 'uses component trace, trace_size, and extended settings when provided' do
+      logger = component_options_class.new.log
+      expect(logger.trace_enabled).to be false
+      expect(logger.extended).to be false
+      expect(logger.instance_variable_get(:@trace_size)).to eq(7)
+    end
+
     it 'memoizes the logger instance' do
       obj = bare_class.new
       first = obj.log
       expect(obj.log).to equal(first)
+    end
+
+    it 'refreshes a memoized logger when Legion::Logging is reconfigured' do
+      obj = bare_class.new
+      first = obj.log
+
+      Legion::Logging.setup(level: 'info', async: false, color: false)
+      second = obj.log
+
+      expect(second).not_to equal(first)
+      expect(second.level).to eq(Legion::Logging::TaggedLogger::LEVELS[:info])
+    end
+
+    it 'prefers runtime Legion::Logging settings over loaded global settings' do
+      stub_const('Legion::Settings', Module.new do
+        def self.loaded? = true
+
+        def self.[](key)
+          return { level: 'info', trace: true, extended: true } if key == :logging
+
+          nil
+        end
+      end)
+
+      logger = bare_class.new.log
+
+      expect(logger.level).to eq(0)
+    end
+
+    it 'uses top-level Legion::Settings component log_level when no local settings method exists' do
+      stub_const('Legion::Settings', Module.new do
+        def self.loaded? = true
+
+        def self.[](key)
+          return { log_level: 'error', logger: { trace: false } } if key == :transport
+          return { level: 'info', trace: true, extended: true } if key == :logging
+
+          nil
+        end
+
+        def self.dig(*)
+          nil
+        end
+      end)
+
+      logger = transport_class.new.log
+
+      expect(logger.level).to eq(Legion::Logging::TaggedLogger::LEVELS[:error])
+      expect(logger.trace_enabled).to be false
+    end
+
+    it 'uses Legion::Settings extension log_level for lex-style components' do
+      stub_const('Legion::Settings', Module.new do
+        def self.loaded? = true
+
+        def self.[](key)
+          return nil unless key == :microsoft_teams
+
+          nil
+        end
+
+        def self.dig(*keys)
+          return { log_level: 'warn', logger: { extended: false } } if keys == %i[extensions microsoft_teams]
+
+          nil
+        end
+      end)
+
+      logger = lex_filename_class.new.log
+
+      expect(logger.level).to eq(Legion::Logging::TaggedLogger::LEVELS[:warn])
+      expect(logger.extended).to be false
+    end
+
+    it 'uses global logging settings for lex-style components without explicit extension logger config' do
+      stub_const('Legion::Settings', Module.new do
+        def self.loaded? = true
+
+        def self.[](key)
+          return { level: 'debug', trace: true, trace_size: 8, extended: true } if key == :logging
+          return {} if key == :extensions
+
+          nil
+        end
+
+        def self.dig(*keys)
+          return nil if keys == %i[extensions microsoft_teams]
+
+          nil
+        end
+      end)
+      allow(Legion::Logging).to receive(:current_settings).and_return({})
+
+      logger = extension_settings_helper_class.new.log
+
+      expect(logger.level).to eq(Legion::Logging::TaggedLogger::LEVELS[:debug])
+      expect(logger.trace_enabled).to be true
+      expect(logger.extended).to be true
+      expect(logger.instance_variable_get(:@trace_size)).to eq(8)
+    end
+
+    it 'uses global trace, trace_size, and extended settings when no component override exists' do
+      stub_const('Legion::Settings', Module.new do
+        def self.loaded? = true
+
+        def self.[](key)
+          return { level: 'info', trace: false, trace_size: 11, extended: false } if key == :logging
+
+          nil
+        end
+
+        def self.dig(*)
+          nil
+        end
+      end)
+      allow(Legion::Logging).to receive(:current_settings).and_return({})
+
+      logger = bare_class.new.log
+
+      expect(logger.trace_enabled).to be false
+      expect(logger.extended).to be false
+      expect(logger.instance_variable_get(:@trace_size)).to eq(11)
+    end
+
+    it 'prefers runtime trace, trace_size, and extended settings over loaded global settings' do
+      stub_const('Legion::Settings', Module.new do
+        def self.loaded? = true
+
+        def self.[](key)
+          return { level: 'info', trace: true, trace_size: 4, extended: true } if key == :logging
+
+          nil
+        end
+
+        def self.dig(*)
+          nil
+        end
+      end)
+      allow(Legion::Logging).to receive(:current_settings).and_return(
+        level: 'debug', trace: false, trace_size: 12, extended: false
+      )
+
+      logger = bare_class.new.log
+
+      expect(logger.trace_enabled).to be false
+      expect(logger.extended).to be false
+      expect(logger.instance_variable_get(:@trace_size)).to eq(12)
     end
   end
 
@@ -195,6 +435,49 @@ RSpec.describe Legion::Logging::Helper do
         end
       end
     end
+
+    context 'without structured exception support' do
+      before do
+        hide_const('Legion::Logging::EventBuilder')
+      end
+
+      it 'still writes a human-readable exception line' do
+        exc = StandardError.new('fallback error')
+        subject.handle_exception(exc)
+        expect(underlying_logger).to have_received(:error).with(/StandardError: fallback error/)
+      end
+    end
+  end
+
+  describe 'TaggedLogger unknown fallback' do
+    it 'still emits unknown messages when Legion::Logging.unknown is unavailable' do
+      bare = bare_class.new
+      allow(Legion::Logging).to receive(:unknown).and_raise(NoMethodError)
+      allow(Legion::Logging).to receive(:respond_to?).and_call_original
+      allow(Legion::Logging).to receive(:respond_to?).with(:unknown).and_return(false)
+
+      expect { bare.log.unknown('purple test') }.to output(/purple test/).to_stdout_from_any_process
+    end
+  end
+
+  describe 'TaggedLogger component-level emission' do
+    let(:debug_component_class) do
+      Class.new do
+        include Legion::Logging::Helper
+
+        def settings
+          { log_level: 'debug' }
+        end
+      end
+    end
+
+    it 'emits debug output when the component log level is lower than the global log level' do
+      Legion::Logging.setup(level: 'info', async: false, color: false)
+      logger = debug_component_class.new.log
+
+      expect { logger.debug('component debug probe') }.to output(/component debug probe/).to_stdout_from_any_process
+      expect { logger.debug('component debug probe') }.to output(/DEBUG/).to_stdout_from_any_process
+    end
   end
 
   describe '.current_log_method' do
@@ -264,9 +547,11 @@ RSpec.describe Legion::Logging::Helper do
 
   describe 'default settings' do
     it 'returns Legion::Logging::Settings.default when Legion::Settings is not defined' do
+      Legion::Logging.instance_variable_set(:@current_settings, nil)
       obj = bare_class.new
       expected = Legion::Logging::Settings.default
-      expect(obj.send(:settings)).to eq({ logger: expected })
+      expect(obj.send(:global_logger_settings)).to eq(expected)
+      expect(obj.send(:resolve_logger_settings)).to eq(expected)
     end
   end
 end

--- a/spec/legion/logging/helper_spec.rb
+++ b/spec/legion/logging/helper_spec.rb
@@ -554,4 +554,16 @@ RSpec.describe Legion::Logging::Helper do
       expect(obj.send(:resolve_logger_settings)).to eq(expected)
     end
   end
+
+  describe 'TaggedLogger defaults' do
+    it 'matches Legion::Logging::Settings.default for direct instantiation' do
+      logger = Legion::Logging::TaggedLogger.new(segments: %w[direct])
+      defaults = Legion::Logging::Settings.default
+
+      expect(logger.level).to eq(Legion::Logging::TaggedLogger::LEVELS.fetch(defaults[:level]))
+      expect(logger.trace_enabled).to be(defaults[:trace])
+      expect(logger.extended).to be(defaults[:extended])
+      expect(logger.instance_variable_get(:@trace_size)).to eq(defaults[:trace_size])
+    end
+  end
 end

--- a/spec/legion/logging/log_exception_spec.rb
+++ b/spec/legion/logging/log_exception_spec.rb
@@ -116,4 +116,25 @@ RSpec.describe 'Legion::Logging.log_exception' do
     Legion::Logging.log_exception(error)
     expect(captured).to eq(ENV.fetch('USER', nil))
   end
+
+  it 'redacts the sync log line and structured event when redaction is enabled' do
+    fake_loader = double('loader')
+    captured = nil
+    stub_const('Legion::Settings', Module.new)
+    Legion::Settings.instance_variable_set(:@loader, fake_loader)
+    allow(fake_loader).to receive(:dig).and_return(nil)
+    allow(fake_loader).to receive(:dig).with(:logging, :redaction, :enabled).and_return(true)
+    Legion::Logging.exception_writer = lambda { |event, **|
+      captured = event
+    }
+
+    redacted_error = RuntimeError.new('SSN 123-45-6789')
+    redacted_error.set_backtrace(error.backtrace)
+
+    expect(Legion::Logging.log).to receive(:error).with(include('[REDACTED]')).and_call_original
+    Legion::Logging.log_exception(redacted_error)
+
+    expect(captured[:message]).to include('[REDACTED]')
+    expect(captured[:message]).not_to include('123-45-6789')
+  end
 end

--- a/spec/legion/logging/redactor_spec.rb
+++ b/spec/legion/logging/redactor_spec.rb
@@ -124,6 +124,36 @@ RSpec.describe Legion::Logging::Redactor do
       result = described_class.redact(event)
       expect(result['password']).to eq('[REDACTED]')
     end
+
+    it 'redacts auth_token style fields' do
+      event  = { auth_token: 'top-secret-token' }
+      result = described_class.redact(event)
+      expect(result[:auth_token]).to eq('[REDACTED]')
+    end
+
+    it 'redacts client_secret style fields' do
+      event  = { client_secret: 'super-secret' }
+      result = described_class.redact(event)
+      expect(result[:client_secret]).to eq('[REDACTED]')
+    end
+
+    it 'redacts access_token style fields' do
+      event  = { access_token: 'oauth-token' }
+      result = described_class.redact(event)
+      expect(result[:access_token]).to eq('[REDACTED]')
+    end
+
+    it 'redacts private_key style fields' do
+      event  = { private_key: '-----BEGIN PRIVATE KEY-----' }
+      result = described_class.redact(event)
+      expect(result[:private_key]).to eq('[REDACTED]')
+    end
+
+    it 'does not redact known non-secret key fields' do
+      event  = { routing_key: 'legion.logging.log.info.core.unknown' }
+      result = described_class.redact(event)
+      expect(result[:routing_key]).to eq('legion.logging.log.info.core.unknown')
+    end
   end
 
   describe 'custom patterns' do
@@ -152,6 +182,21 @@ RSpec.describe Legion::Logging::Redactor do
 
     it 'returns empty hash when Legion::Settings is not defined' do
       expect(described_class.send(:custom_patterns)).to eq({})
+    end
+
+    it 'refreshes cached patterns without restarting the process' do
+      stub_const('Legion::Settings', Module.new)
+      allow(Legion::Settings).to receive(:[]).and_return(nil)
+      allow(Legion::Settings).to receive(:dig).with(:logging, :redactor, :custom_patterns)
+                                              .and_return({ 'member_id' => '\bU\d{9}\b' },
+                                                          { 'account_id' => '\bA\d{6}\b' })
+
+      expect(described_class.redact_string('member U123456789 enrolled')).to include('[REDACTED]')
+      expect(described_class.redact_string('account A123456 active')).to include('A123456')
+
+      described_class.refresh_patterns!
+
+      expect(described_class.redact_string('account A123456 active')).to include('[REDACTED]')
     end
   end
 

--- a/spec/legion/logging/shipper/file_transport_spec.rb
+++ b/spec/legion/logging/shipper/file_transport_spec.rb
@@ -67,10 +67,47 @@ RSpec.describe Legion::Logging::Shipper::FileTransport do
       hide_const('Legion::Settings') if defined?(Legion::Settings)
       allow(File).to receive(:open).and_return(nil)
       allow(FileUtils).to receive(:mkdir_p)
-      io = double('io', puts: nil)
+      io = double('io', write: nil)
       allow(File).to receive(:open).with(described_class::DEFAULT_PATH, 'a').and_yield(io)
-      expect(io).to receive(:puts)
+      expect(io).to receive(:write).at_least(:once)
       described_class.ship({ level: 'warn', message: 'fallback' })
+    end
+  end
+
+  describe '.ship_batch' do
+    it 'writes one JSON object per line for a batch' do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, 'siem.log')
+        stub_const('Legion::Settings', Module.new)
+        allow(Legion::Settings).to receive(:[]).and_return(nil)
+        allow(Legion::Settings).to receive(:dig).with(:logging, :shipper, :file, :path).and_return(path)
+
+        described_class.ship_batch([{ level: 'error', message: 'first' }, { level: 'warn', message: 'second' }])
+
+        lines = File.readlines(path, chomp: true)
+        expect(lines.size).to eq(2)
+        expect(JSON.parse(lines[0])).to eq('level' => 'error', 'message' => 'first')
+        expect(JSON.parse(lines[1])).to eq('level' => 'warn', 'message' => 'second')
+      end
+    end
+
+    it 'opens the file once per batch' do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, 'siem.log')
+        stub_const('Legion::Settings', Module.new)
+        allow(Legion::Settings).to receive(:[]).and_return(nil)
+        allow(Legion::Settings).to receive(:dig).with(:logging, :shipper, :file, :path).and_return(path)
+
+        open_calls = 0
+        allow(File).to receive(:open).and_wrap_original do |original, *args, &block|
+          open_calls += 1 if args == [path, 'a']
+          original.call(*args, &block)
+        end
+
+        described_class.ship_batch([{ level: 'error', message: 'first' }, { level: 'warn', message: 'second' }])
+
+        expect(open_calls).to eq(1)
+      end
     end
   end
 end

--- a/spec/legion/logging/shipper_spec.rb
+++ b/spec/legion/logging/shipper_spec.rb
@@ -89,17 +89,37 @@ RSpec.describe Legion::Logging::Shipper do
     it 'calls the transport with buffered events' do
       described_class.instance_variable_set(:@mutex, Mutex.new)
       described_class.instance_variable_set(:@buffer, [{ level: 'error', message: 'test' }])
-      allow(Legion::Logging::Shipper::FileTransport).to receive(:ship).and_return(true)
+      allow(Legion::Logging::Shipper::FileTransport).to receive(:ship_batch).and_return(true)
       described_class.flush
-      expect(Legion::Logging::Shipper::FileTransport).to have_received(:ship)
+      expect(Legion::Logging::Shipper::FileTransport).to have_received(:ship_batch).with([{ level: 'error', message: 'test' }])
     end
 
     it 'clears the buffer after flushing' do
       described_class.instance_variable_set(:@mutex, Mutex.new)
       described_class.instance_variable_set(:@buffer, [{ level: 'error', message: 'test' }])
-      allow(Legion::Logging::Shipper::FileTransport).to receive(:ship).and_return(true)
+      allow(Legion::Logging::Shipper::FileTransport).to receive(:ship_batch).and_return(true)
       described_class.flush
       expect(described_class.instance_variable_get(:@buffer)).to be_empty
+    end
+
+    it 'retains the buffer when delivery returns false' do
+      described_class.instance_variable_set(:@mutex, Mutex.new)
+      described_class.instance_variable_set(:@buffer, [{ level: 'error', message: 'test' }])
+      allow(Legion::Logging::Shipper::FileTransport).to receive(:ship_batch).and_return(false)
+
+      described_class.flush
+
+      expect(described_class.instance_variable_get(:@buffer)).to eq([{ level: 'error', message: 'test' }])
+    end
+
+    it 'retains the buffer when delivery raises' do
+      described_class.instance_variable_set(:@mutex, Mutex.new)
+      described_class.instance_variable_set(:@buffer, [{ level: 'error', message: 'test' }])
+      allow(Legion::Logging::Shipper::FileTransport).to receive(:ship_batch).and_raise(StandardError, 'boom')
+
+      described_class.flush
+
+      expect(described_class.instance_variable_get(:@buffer)).to eq([{ level: 'error', message: 'test' }])
     end
   end
 
@@ -156,20 +176,38 @@ RSpec.describe Legion::Logging::Shipper do
 
     it 'uses file transport when configured' do
       allow(Legion::Settings).to receive(:dig).with(:logging, :shipper, :transport).and_return('file')
-      allow(Legion::Logging::Shipper::FileTransport).to receive(:ship).and_return(true)
+      allow(Legion::Logging::Shipper::FileTransport).to receive(:ship_batch).and_return(true)
       described_class.instance_variable_set(:@mutex, Mutex.new)
       described_class.instance_variable_set(:@buffer, [])
       described_class.ship({ level: 'debug', message: 'test' })
-      expect(Legion::Logging::Shipper::FileTransport).to have_received(:ship)
+      expect(Legion::Logging::Shipper::FileTransport).to have_received(:ship_batch).with([{ level: 'debug', message: 'test' }])
     end
 
     it 'uses http transport when configured' do
       allow(Legion::Settings).to receive(:dig).with(:logging, :shipper, :transport).and_return('http')
-      allow(Legion::Logging::Shipper::HttpTransport).to receive(:ship).and_return(true)
+      allow(Legion::Logging::Shipper::HttpTransport).to receive(:ship_batch).and_return(true)
       described_class.instance_variable_set(:@mutex, Mutex.new)
       described_class.instance_variable_set(:@buffer, [])
       described_class.ship({ level: 'debug', message: 'test' })
-      expect(Legion::Logging::Shipper::HttpTransport).to have_received(:ship)
+      expect(Legion::Logging::Shipper::HttpTransport).to have_received(:ship_batch).with([{ level: 'debug', message: 'test' }])
+    end
+  end
+
+  describe '.start' do
+    it 'preserves events buffered before the flush thread starts' do
+      stub_const('Legion::Settings', Module.new)
+      allow(Legion::Settings).to receive(:[]).and_return(nil)
+      allow(Legion::Settings).to receive(:dig).and_return(nil)
+      allow(Legion::Settings).to receive(:dig).with(:logging, :shipper, :enabled).and_return(true)
+      allow(Legion::Settings).to receive(:dig).with(:logging, :shipper, :flush_interval).and_return(60)
+
+      described_class.instance_variable_set(:@buffer, [{ level: 'error', message: 'buffered first' }])
+      described_class.instance_variable_set(:@mutex, Mutex.new)
+      described_class.start
+
+      expect(described_class.instance_variable_get(:@buffer)).to eq([{ level: 'error', message: 'buffered first' }])
+      described_class.instance_variable_get(:@flush_thread)&.kill
+      described_class.instance_variable_set(:@flush_thread, nil)
     end
   end
 end

--- a/spec/legion/multi_io_spec.rb
+++ b/spec/legion/multi_io_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe Legion::Logging::MultiIO do
       io.close
       expect(File.read(log_file)).to include('hello')
     end
+
+    it 'does not flush each target on every write' do
+      target = instance_double(IO)
+      allow(target).to receive(:write)
+      allow(target).to receive(:flush)
+      io = described_class.new(target)
+
+      io.write("hello\n")
+
+      expect(target).to have_received(:write).with("hello\n")
+      expect(target).not_to have_received(:flush)
+    end
   end
 
   describe '#close' do


### PR DESCRIPTION
## What

- fix async writer shutdown and shipper delivery semantics so buffered and in-flight events are not silently dropped
- fix file transport batch behavior and remove per-write flush amplification in `MultiIO`
- preserve producer-thread caller metadata for async extended logging
- enforce structured event size caps and close remaining redaction gaps in sync and structured exception logging

## Why

This release branch was still leaving open correctness issues in async delivery, transport batching, event-size enforcement, and redaction behavior. These changes close those gaps before `1.5.0` merges.

## Closes On Merge

- Closes #10 prevent dropped log events in async writer and shipper
- Closes #11 fix file transport batch semantics and reduce write amplification
- Closes #12 preserve caller metadata and enforce event size contracts
- Closes #13 close redaction leaks in exception and structured logs

## Checklist

- [x] Tests pass (`bundle exec rspec`)
- [x] RuboCop passes (`bundle exec rubocop`)
- [x] CHANGELOG.md updated (if user-facing change)
- [x] No new security concerns introduced
