### PR TITLE
add method tracer, backtrace formatting in log_exception, and helper lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Legion::Logging Changelog
 
-## [1.5.0] - 2026-04-02
+## [1.5.0] - 2026-04-08
 
 ### Added
+- `Legion::Logging::MethodTracer` module: opt-in TracePoint-based method call tracing with indent-aware call/return output and parameter formatting
+- `Helper.included` / `Helper.extended` hooks auto-attach `MethodTracer` when `MethodTracer::ENABLED` is true
+- `log_exception` now formats backtrace (up to 10 frames + overflow count) inline in the stdout/file log line
 - `Legion::Logging.current_settings` and `.configuration_generation` so helper mixins can refresh memoized tagged loggers after runtime reconfiguration
 - Component logger overrides from local `settings`, top-level `Legion::Settings[component]`, and `Legion::Settings.dig(:extensions, component)` for `log_level`, `trace`, `trace_size`, and `extended`
 - `Methods#emit_tagged` / `TaggedLogger#dispatch` path so component-level loggers can emit with their own level while preserving tagged context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Legion::Logging Changelog
 
-## [1.5.0] - 2026-04-08
+## [1.5.1] - 2026-04-08
 
 ### Added
 - `Legion::Logging::MethodTracer` module: opt-in TracePoint-based method call tracing with indent-aware call/return output and parameter formatting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,40 +8,50 @@
 Ruby logging class for the LegionIO framework. Provides colorized console output via Rainbow, structured JSON logging (`format: :json`), and a consistent logging interface across all Legion gems and extensions.
 
 **GitHub**: https://github.com/LegionIO/legion-logging
-**Version**: 1.3.2
+**Version**: 1.5.0
 **License**: Apache-2.0
 
 ## Architecture
 
 ```
 Legion::Logging (singleton module)
-├── Methods         # Log level methods: debug, info, warn, error, fatal, unknown
-├── Builder         # Output destination (stdout/file), log level, formatter, async: keyword
-├── AsyncWriter     # Non-blocking SizedQueue-backed writer thread; fatal calls bypass queue
-├── Hooks           # Callback registry for fatal/error/warn events (on_fatal, on_error, on_warn)
-├── EventBuilder    # Structured event payload builder (caller, exception, lex, gem metadata)
-├── Helper          # Injectable log mixin for LEX extensions (derives logger tags from segments/class)
-├── Logger          # Core logger configuration and setup
-├── MultiIO         # Write to multiple destinations simultaneously
-├── SIEMExporter    # PHI-redacting SIEM export (Splunk HEC, ELK/OpenSearch)
-├── Shipper         # Buffered log event forwarding (file/http transports)
-├── Redactor        # PII/PHI pattern redaction
-└── Version         # VERSION constant
+├── Methods           # Log level methods: debug, info, warn, error, fatal, unknown; log_exception helper
+├── Builder           # Output destination (stdout/file), log level, formatter, async: keyword
+├── AsyncWriter       # Non-blocking SizedQueue-backed writer thread; fatal calls bypass queue
+├── Hooks             # Callback registry for fatal/error/warn events (on_fatal, on_error, on_warn)
+├── EventBuilder      # Structured event payload builder (caller, exception, lex, gem metadata); fingerprint for dedup
+├── Helper            # Injectable log mixin for LEX extensions (derives logger tags from segments/class)
+├── Logger            # Core logger configuration and setup
+├── MultiIO           # Write to multiple destinations simultaneously
+├── TaggedLogger      # Logger wrapper that prepends structured tags to each message
+├── CategoryRegistry  # Registry of named log categories with description and expected_fields
+├── MethodTracer      # Tracing module for instrumenting method calls (timing, args)
+├── SIEMExporter      # PHI-redacting SIEM export (Splunk HEC, ELK/OpenSearch)
+├── Shipper           # Buffered log event forwarding; sub-transports: FileTransport, HttpTransport
+├── Redactor          # PII/PHI + secret pattern redaction; opt-in via logging.redaction.enabled
+└── Version           # VERSION constant
+
+# Module-level writers (pluggable lambda slots replacing old Hooks for AMQP forwarding)
+Legion::Logging.log_writer       # -> lambda(->(event, routing_key:) {})
+Legion::Logging.exception_writer # -> lambda(->(event, routing_key:, headers:, properties:) {})
 ```
 
 ### Key Design Patterns
 
-- **Singleton Module**: `Legion::Logging` uses `class << self` - called directly: `Legion::Logging.info("msg")`
-- **Rainbow Colorization**: Console output uses Rainbow gem for colored terminal output
-- **Setup Method**: `Legion::Logging.setup(log_file:, level:, async: true)` configures output destination, level, and async mode
-- **Async by Default**: `setup` enables async logging — calls return immediately. Fatal calls always bypass the queue. `stop_async_writer` flushes and stops on shutdown. Buffer size configurable via `Legion::Settings.dig(:logging, :async, :buffer_size)` (default 10,000). Back-pressure: callers block when buffer is full.
-- **Structured JSON**: `format: :json` in settings outputs machine-parseable JSON log lines
+- **Singleton Module**: `Legion::Logging` uses `class << self` — called directly: `Legion::Logging.info("msg")`
+- **Rainbow Colorization**: Console output uses Rainbow gem for colored terminal output. Color auto-disabled in JSON format and when writing to a log file.
+- **Setup Method**: `Legion::Logging.setup(level:, format:, async:, **options)` configures output, level, format, and async mode. Increments `configuration_generation` on each call.
+- **Async by Default**: `setup` enables async logging — calls return immediately. Fatal calls always bypass the queue. `stop_async_writer` flushes and stops on shutdown. Buffer size configurable via `Legion::Settings[:logging][:async][:buffer_size]` (default 10,000). Back-pressure: callers block when buffer is full.
+- **Structured JSON**: `format: :json` in settings outputs machine-parseable JSON log lines (disables color)
 - **Shared Interface**: Same method signature (`info`, `warn`, `error`, etc.) across all Legion components
 - **MultiIO**: Splits writes to stdout and a log file simultaneously (used by Builder when `log_file` is set)
 - **SIEMExporter**: PHI redaction (SSN, phone, MRN, DOB patterns), `export_to_splunk` (HEC), `format_for_elk`
-- **Hook Callbacks**: `on_fatal`, `on_error`, `on_warn` register procs called after each log at those levels. Hooks are gated by `enable_hooks!`/`disable_hooks!`. Hook failures are silently rescued — never impact the logger. Hooks fire on the async writer thread; event context captured on caller thread.
-- **EventBuilder**: Builds structured event hashes from log context (caller location, exception info, lex identity, gem metadata). All from in-memory data, zero IO.
+- **Hook Callbacks**: `on_fatal`, `on_error`, `on_warn` register procs called after each log at those levels. Hooks are gated by `enable_hooks!`/`disable_hooks!`. Hook failures are silently rescued. Hooks fire on the async writer thread; event context captured on caller thread.
+- **EventBuilder**: Builds structured event hashes from log context (caller location, exception info, lex identity, gem metadata). All from in-memory data, zero IO. `fingerprint` produces MD5 for dedup in log aggregation.
 - **Helper mixin**: `Legion::Logging::Helper` is injectable into LEX extensions. Derives logger tags from `segments`, `lex_filename`, or class name. Passes through `settings[:logger]` config when available.
+- **Writer Lambdas**: `log_writer` and `exception_writer` are module-level lambda slots for forwarding to external systems (AMQP, etc.). Default implementations are no-ops. Set via `Legion::Logging.log_writer = lambda`.
+- **CategoryRegistry**: Named log categories with description and expected_fields. Register via `Legion::Logging.register_category`. Used for structured log validation.
+- **Redactor**: Opt-in PII/PHI redaction (`logging.redaction.enabled: true`). Guards against Settings recursive init via `@loader` ivar check. Patterns: SSN, phone, MRN, DOB, Vault tokens, JWTs, bearer tokens, lease IDs.
 
 ## Dependencies
 
@@ -62,7 +72,15 @@ Legion::Logging (singleton module)
 | `lib/legion/logging/multi_io.rb` | Multi-output IO (write to multiple destinations simultaneously) |
 | `lib/legion/logging/siem_exporter.rb` | PHI-redacting SIEM export helpers (Splunk HEC, ELK format) |
 | `lib/legion/logging/hooks.rb` | Callback registry (fatal/error/warn hook arrays, enable/disable/clear) |
-| `lib/legion/logging/event_builder.rb` | Structured event payload builder |
+| `lib/legion/logging/event_builder.rb` | Structured event payload builder; `fingerprint` for MD5 dedup |
+| `lib/legion/logging/tagged_logger.rb` | Logger wrapper that prepends structured tags to each message |
+| `lib/legion/logging/category_registry.rb` | Named log category registration and lookup |
+| `lib/legion/logging/method_tracer.rb` | Method call tracing instrumentation (timing, args) |
+| `lib/legion/logging/shipper.rb` | Buffered log event forwarding to external systems |
+| `lib/legion/logging/shipper/file_transport.rb` | File-based log shipper transport |
+| `lib/legion/logging/shipper/http_transport.rb` | HTTP-based log shipper transport |
+| `lib/legion/logging/siem_exporter.rb` | PHI-redacting SIEM export (Splunk HEC, ELK format) |
+| `lib/legion/logging/redactor.rb` | PII/PHI + secret pattern redaction (opt-in) |
 | `lib/legion/logging/version.rb` | VERSION constant |
 
 ## Role in LegionIO

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Legion::Logging (singleton module)
 ├── MultiIO           # Write to multiple destinations simultaneously
 ├── TaggedLogger      # Logger wrapper that prepends structured tags to each message
 ├── CategoryRegistry  # Registry of named log categories with description and expected_fields
-├── MethodTracer      # Tracing module for instrumenting method calls (timing, args)
+├── MethodTracer      # Tracing module for instrumenting method calls (call/return, formatted args)
 ├── SIEMExporter      # PHI-redacting SIEM export (Splunk HEC, ELK/OpenSearch)
 ├── Shipper           # Buffered log event forwarding; sub-transports: FileTransport, HttpTransport
 ├── Redactor          # PII/PHI + secret pattern redaction; opt-in via logging.redaction.enabled
@@ -75,7 +75,7 @@ Legion::Logging.exception_writer # -> lambda(->(event, routing_key:, headers:, p
 | `lib/legion/logging/event_builder.rb` | Structured event payload builder; `fingerprint` for MD5 dedup |
 | `lib/legion/logging/tagged_logger.rb` | Logger wrapper that prepends structured tags to each message |
 | `lib/legion/logging/category_registry.rb` | Named log category registration and lookup |
-| `lib/legion/logging/method_tracer.rb` | Method call tracing instrumentation (timing, args) |
+| `lib/legion/logging/method_tracer.rb` | Method call tracing instrumentation (call/return, formatted args) |
 | `lib/legion/logging/shipper.rb` | Buffered log event forwarding to external systems |
 | `lib/legion/logging/shipper/file_transport.rb` | File-based log shipper transport |
 | `lib/legion/logging/shipper/http_transport.rb` | HTTP-based log shipper transport |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Logging module for the [LegionIO](https://github.com/LegionIO/LegionIO) framework. Provides colorized console output via Rainbow, structured JSON logging, multi-output IO, and a consistent logging interface across all Legion gems and extensions.
 
-**Version**: 1.4.1
+**Version**: 1.5.0
 
 ## Installation
 

--- a/lib/legion/logging/helper.rb
+++ b/lib/legion/logging/helper.rb
@@ -2,6 +2,7 @@
 
 require 'securerandom'
 require_relative 'tagged_logger'
+require_relative 'method_tracer'
 
 module Legion
   module Logging
@@ -100,6 +101,14 @@ module Legion
 
         write_exception_to_log(exception, event, level, segments)
         publish_exception(event, level) if structured_exception_support?
+      end
+
+      def self.included(base)
+        MethodTracer.attach(base) if defined?(MethodTracer) && MethodTracer::ENABLED
+      end
+
+      def self.extended(base)
+        MethodTracer.attach(base, match_singleton: true) if defined?(MethodTracer) && MethodTracer::ENABLED
       end
 
       private

--- a/lib/legion/logging/method_tracer.rb
+++ b/lib/legion/logging/method_tracer.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Legion
+  module Logging
+    module MethodTracer
+      ENABLED = false
+
+      def self.attach(base, match_singleton: false)
+        return unless ENABLED
+
+        base_name = base.to_s
+        TracePoint.new(:call, :return) do |tp|
+          next unless tp.defined_class == base || (match_singleton && tp.defined_class == base.singleton_class)
+
+          stack = (Thread.current[:_legion_trace_stack] ||= [])
+
+          case tp.event
+          when :call
+            params = format_params(tp)
+            indent = '  ' * stack.size
+            puts "#{indent}-> #{tp.method_id}, #{base_name}, #{params.join(', ')}"
+            stack.push(tp.method_id)
+          when :return
+            stack.pop
+            indent = '  ' * stack.size
+            puts "#{indent}<- #{tp.method_id}, #{base_name}"
+          end
+        end.enable
+      end
+
+      def self.format_params(trace_point)
+        trace_point.parameters.filter_map do |type, name|
+          next unless name
+
+          val = begin
+            trace_point.binding.local_variable_get(name)
+          rescue StandardError
+            '?'
+          end
+          case type
+          when :req, :opt then "#{name}=#{val.inspect}"
+          when :keyreq, :key then "#{name}: #{val.inspect}"
+          when :rest then "*#{name}"
+          when :keyrest then "**#{name}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/logging/method_tracer.rb
+++ b/lib/legion/logging/method_tracer.rb
@@ -4,28 +4,52 @@ module Legion
   module Logging
     module MethodTracer
       ENABLED = false
+      ATTACHED = {} # rubocop:disable Style/MutableConstant
+      ATTACHED_MUTEX = Mutex.new
+      private_constant :ATTACHED_MUTEX
 
       def self.attach(base, match_singleton: false)
         return unless ENABLED
 
-        base_name = base.to_s
-        TracePoint.new(:call, :return) do |tp|
-          next unless tp.defined_class == base || (match_singleton && tp.defined_class == base.singleton_class)
+        ATTACHED_MUTEX.synchronize do
+          return if ATTACHED.key?(base)
 
-          stack = (Thread.current[:_legion_trace_stack] ||= [])
+          base_name = base.to_s
+          tp = TracePoint.new(:call, :return) do |trace|
+            next unless trace.defined_class == base || (match_singleton && trace.defined_class == base.singleton_class)
 
-          case tp.event
-          when :call
-            params = format_params(tp)
-            indent = '  ' * stack.size
-            puts "#{indent}-> #{tp.method_id}, #{base_name}, #{params.join(', ')}"
-            stack.push(tp.method_id)
-          when :return
-            stack.pop
-            indent = '  ' * stack.size
-            puts "#{indent}<- #{tp.method_id}, #{base_name}"
+            stack = (Thread.current[:_legion_trace_stack] ||= [])
+
+            case trace.event
+            when :call
+              params = format_params(trace)
+              params_segment = params.empty? ? '' : ", #{params.join(', ')}"
+              indent = '  ' * stack.size
+              puts "#{indent}-> #{trace.method_id}, #{base_name}#{params_segment}"
+              stack.push(trace.method_id)
+            when :return
+              stack.pop
+              indent = '  ' * stack.size
+              puts "#{indent}<- #{trace.method_id}, #{base_name}"
+            end
           end
-        end.enable
+          tp.enable
+          ATTACHED[base] = tp
+        end
+      end
+
+      def self.detach(base)
+        ATTACHED_MUTEX.synchronize do
+          tp = ATTACHED.delete(base)
+          tp&.disable
+        end
+      end
+
+      def self.detach_all
+        ATTACHED_MUTEX.synchronize do
+          ATTACHED.each_value(&:disable)
+          ATTACHED.clear
+        end
       end
 
       def self.format_params(trace_point)

--- a/lib/legion/logging/methods.rb
+++ b/lib/legion/logging/methods.rb
@@ -104,9 +104,17 @@ module Legion
                         source_code_uri: nil, handled: false, payload_summary: nil,
                         task_id: nil, **extra)
         level = level.to_sym if level.respond_to?(:to_sym)
-        # 1. Log human-readable line to stdout/file (bypass writer callbacks)
+        # 1. Log human-readable line + backtrace to stdout/file (bypass writer callbacks)
         msg = exception.respond_to?(:message) ? exception.message : exception.to_s
         msg = maybe_redact(msg)
+        bt = Array(exception.backtrace)
+        if bt.any?
+          lines = ["#{exception.class}: #{msg}"]
+          bt.first(10).each { |frame| lines << "  #{frame}" }
+          remaining = bt.length - 10
+          lines << "  ... #{remaining} more" if remaining.positive?
+          msg = lines.join("\n")
+        end
         log.public_send(level, msg) if respond_to?(:log) && log.respond_to?(level)
 
         # 2. Build rich exception event

--- a/lib/legion/logging/methods.rb
+++ b/lib/legion/logging/methods.rb
@@ -109,9 +109,10 @@ module Legion
         msg = maybe_redact(msg)
         bt = Array(exception.backtrace)
         if bt.any?
+          limit = defined?(Legion::Logging::Helper::EXCEPTION_BACKTRACE_LIMIT) ? Legion::Logging::Helper::EXCEPTION_BACKTRACE_LIMIT : 10
           lines = ["#{exception.class}: #{msg}"]
-          bt.first(10).each { |frame| lines << "  #{frame}" }
-          remaining = bt.length - 10
+          bt.first(limit).each { |frame| lines << "  #{frame}" }
+          remaining = bt.length - limit
           lines << "  ... #{remaining} more" if remaining.positive?
           msg = lines.join("\n")
         end

--- a/lib/legion/logging/version.rb
+++ b/lib/legion/logging/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Logging
-    VERSION = '1.5.0'
+    VERSION = '1.5.1'
   end
 end

--- a/spec/legion/logging/log_exception_spec.rb
+++ b/spec/legion/logging/log_exception_spec.rb
@@ -117,6 +117,40 @@ RSpec.describe 'Legion::Logging.log_exception' do
     expect(captured).to eq(ENV.fetch('USER', nil))
   end
 
+  describe 'backtrace formatting in the sync log line' do
+    it 'includes backtrace frames in the logged message when the exception has a backtrace' do
+      expect(Legion::Logging.log).to receive(:error).with(
+        satisfy { |msg| msg.include?('TypeError: wrong argument type') && msg.include?('spec/') }
+      ).and_call_original
+      Legion::Logging.log_exception(error)
+    end
+
+    it 'includes an overflow count line when backtrace exceeds the limit' do
+      deep_error = RuntimeError.new('deep')
+      deep_error.set_backtrace(Array.new(15, 'fake_file.rb:1:in `fake_method`'))
+      expect(Legion::Logging.log).to receive(:error).with(
+        satisfy { |msg| msg.include?('... 5 more') }
+      ).and_call_original
+      Legion::Logging.log_exception(deep_error)
+    end
+
+    it 'does not include an overflow line when backtrace is within the limit' do
+      short_error = RuntimeError.new('short')
+      short_error.set_backtrace(Array.new(3, 'fake_file.rb:1:in `fake_method`'))
+      expect(Legion::Logging.log).to receive(:error).with(
+        satisfy { |msg| !msg.include?('more') }
+      ).and_call_original
+      Legion::Logging.log_exception(short_error)
+    end
+
+    it 'falls back to message-only when the exception has no backtrace' do
+      no_bt_error = RuntimeError.new('no backtrace')
+      # Do not call set_backtrace — backtrace is nil
+      expect(Legion::Logging.log).to receive(:error).with('no backtrace').and_call_original
+      Legion::Logging.log_exception(no_bt_error)
+    end
+  end
+
   it 'redacts the sync log line and structured event when redaction is enabled' do
     fake_loader = double('loader')
     captured = nil

--- a/spec/legion/logging/method_tracer_spec.rb
+++ b/spec/legion/logging/method_tracer_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Legion::Logging::MethodTracer do
+  let(:sample_class) do
+    Class.new do
+      def greet(name)
+        "Hello, #{name}"
+      end
+
+      def no_args
+        :ok
+      end
+    end
+  end
+
+  after do
+    described_class.detach_all
+  end
+
+  describe '.attach' do
+    context 'when ENABLED is false (default)' do
+      it 'does not attach a TracePoint' do
+        described_class.attach(sample_class)
+        expect(described_class::ATTACHED).not_to have_key(sample_class)
+      end
+    end
+
+    context 'when ENABLED is true' do
+      before { stub_const('Legion::Logging::MethodTracer::ENABLED', true) }
+
+      it 'stores the TracePoint in ATTACHED keyed by base' do
+        described_class.attach(sample_class)
+        expect(described_class::ATTACHED).to have_key(sample_class)
+        expect(described_class::ATTACHED[sample_class]).to be_a(TracePoint)
+      end
+
+      it 'is idempotent — attaching twice does not add a second TracePoint' do
+        described_class.attach(sample_class)
+        first_tp = described_class::ATTACHED[sample_class]
+        described_class.attach(sample_class)
+        expect(described_class::ATTACHED[sample_class]).to equal(first_tp)
+        expect(described_class::ATTACHED.count { |k, _| k == sample_class }).to eq(1)
+      end
+
+      it 'prints call/return output for a method with parameters' do
+        described_class.attach(sample_class)
+        obj = sample_class.new
+        output = capture_output { obj.greet('world') }
+        expect(output).to include('-> greet')
+        expect(output).to include('<- greet')
+        expect(output).to include('name=')
+      end
+
+      it 'omits the params segment when a method has no parameters' do
+        described_class.attach(sample_class)
+        obj = sample_class.new
+        output = capture_output { obj.no_args }
+        expect(output).to include('-> no_args')
+        expect(output).not_to match(/-> no_args,\s*,/)
+        expect(output).not_to match(/-> no_args, $/)
+      end
+
+      it 'uses indentation based on call depth' do
+        nested_class = Class.new do
+          def outer
+            inner
+          end
+
+          def inner
+            :done
+          end
+        end
+        described_class.attach(nested_class)
+        obj = nested_class.new
+        output = capture_output { obj.outer }
+        lines = output.lines
+        outer_call = lines.find { |l| l.include?('-> outer') }
+        inner_call = lines.find { |l| l.include?('-> inner') }
+        expect(outer_call).to start_with('->')
+        expect(inner_call).to start_with('  ->')
+      end
+    end
+  end
+
+  describe '.detach' do
+    before { stub_const('Legion::Logging::MethodTracer::ENABLED', true) }
+
+    it 'removes and disables the TracePoint for the given base' do
+      described_class.attach(sample_class)
+      expect(described_class::ATTACHED).to have_key(sample_class)
+      described_class.detach(sample_class)
+      expect(described_class::ATTACHED).not_to have_key(sample_class)
+    end
+
+    it 'is a no-op when base was never attached' do
+      expect { described_class.detach(sample_class) }.not_to raise_error
+    end
+  end
+
+  describe '.detach_all' do
+    before { stub_const('Legion::Logging::MethodTracer::ENABLED', true) }
+
+    it 'clears all attached TracePoints' do
+      other_class = Class.new
+      described_class.attach(sample_class)
+      described_class.attach(other_class)
+      expect(described_class::ATTACHED.size).to eq(2)
+      described_class.detach_all
+      expect(described_class::ATTACHED).to be_empty
+    end
+  end
+
+  describe '.format_params' do
+    it 'returns an empty array for a method with no parameters' do
+      tp_double = instance_double(TracePoint, parameters: [])
+      expect(described_class.format_params(tp_double)).to eq([])
+    end
+
+    it 'formats required and optional positional parameters' do
+      binding_double = double('binding')
+      allow(binding_double).to receive(:local_variable_get).with(:name).and_return('Alice')
+      tp_double = instance_double(TracePoint, parameters: [%i[req name]], binding: binding_double)
+      result = described_class.format_params(tp_double)
+      expect(result).to eq(['name="Alice"'])
+    end
+
+    it 'formats keyword parameters' do
+      binding_double = double('binding')
+      allow(binding_double).to receive(:local_variable_get).with(:key).and_return(42)
+      tp_double = instance_double(TracePoint, parameters: [%i[keyreq key]], binding: binding_double)
+      result = described_class.format_params(tp_double)
+      expect(result).to eq(['key: 42'])
+    end
+
+    it 'returns ? when the local variable cannot be retrieved' do
+      binding_double = double('binding')
+      allow(binding_double).to receive(:local_variable_get).and_raise(NameError)
+      tp_double = instance_double(TracePoint, parameters: [%i[req x]], binding: binding_double)
+      result = described_class.format_params(tp_double)
+      expect(result).to eq(['x="?"'])
+    end
+  end
+
+  # Helper to capture stdout output from puts calls inside a block
+  def capture_output
+    old_stdout = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = old_stdout
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Legion::Logging::MethodTracer` — an opt-in TracePoint-based tracing module that instruments method calls with indent-aware call/return output and parameter formatting (disabled by default via `ENABLED = false`)
- `Helper.included` and `Helper.extended` hooks auto-attach `MethodTracer` when enabled, so any class mixing in `Helper` gets tracing for free
- `log_exception` now includes a formatted backtrace (up to 10 frames + overflow count) inline in the stdout/file log line for better at-a-glance diagnostics

## Test plan

- [ ] RSpec suite passes (95.27% coverage, exit 0)
- [ ] RuboCop clean (6 auto-corrected indentation offenses in method_tracer.rb, exit 0)
- [ ] Verify `MethodTracer::ENABLED = false` by default — no trace output in normal operation
- [ ] Verify `log_exception` log line includes backtrace frames when exception has a backtrace