### PR TITLE
Preserve full exception backtraces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /tmp/
 /legion/.idea/
 /.idea/
+*.gem
 *.key
 # rspec failure tracking
 .rspec_status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Legion::Logging Changelog
 
+## [1.5.2] - 2026-04-27
+
+### Changed
+- Exception stdout/file log lines now include the full backtrace instead of truncating after 10 frames with a `... N more` suffix.
+
 ## [1.5.1] - 2026-04-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Logging module for the [LegionIO](https://github.com/LegionIO/LegionIO) framework. Provides colorized console output via Rainbow, structured JSON logging, multi-output IO, and a consistent logging interface across all Legion gems and extensions.
 
-**Version**: 1.5.0
+**Version**: 1.5.2
 
 ## Installation
 
@@ -96,23 +96,46 @@ end
 
 ### Exception Logging
 
-`log_exception` provides a single call for complete structured exception events with component context:
+`log_exception` provides a single call for complete exception logging with component context. It writes a human-readable exception line through the configured logger and publishes a structured exception event when an `exception_writer` is configured.
 
 ```ruby
-Legion::Logging.log_exception(exception,
-  handled: true,
-  component_type: :runner,
-  lex: 'my_extension',
-  task_id: 'abc-123')
+begin
+  runner.call
+rescue StandardError => e
+  Legion::Logging.log_exception(
+    e,
+    handled: true,
+    component_type: :runner,
+    lex: 'my_extension',
+    task_id: 'abc-123'
+  )
+end
 ```
+
+The synchronous log line includes the full Ruby backtrace. Legion does not truncate it to a fixed frame count or replace the tail with `... N more`, because the missing frames are often the useful part of production failures.
+
+Structured exception events include:
+
+- exception class and message
+- full backtrace array
+- caller file, line, and function where available
+- log level and handled/unhandled status
+- component type, lex name, gem name, version, and source path metadata
+- task and thread context
+- stable error fingerprint for deduplication
 
 ### Writer Lambdas
 
 `log_writer` and `exception_writer` are pluggable lambda slots that replace the old Hooks system. Assign them to forward events to external systems:
 
 ```ruby
-Legion::Logging.exception_writer = ->(payload, routing_key:, headers:, properties:) { publish_to_amqp(payload) }
-Legion::Logging.log_writer = ->(context, routing_key:) { publish_log(context) }
+Legion::Logging.exception_writer = lambda do |payload, routing_key:, headers:, properties:|
+  publish_to_amqp(payload, routing_key:, headers:, properties:)
+end
+
+Legion::Logging.log_writer = lambda do |context, routing_key:|
+  publish_log(context, routing_key:)
+end
 ```
 
 ### EventBuilder
@@ -121,7 +144,9 @@ Legion::Logging.log_writer = ->(context, routing_key:) { publish_log(context) }
 
 ### Redactor
 
-`Legion::Logging::Redactor` redacts PII/PHI patterns (SSN, phone, MRN, DOB) plus Vault tokens, JWTs, bearer tokens, and lease IDs from log messages. Redaction is opt-in: load the module (for example via `require 'legion/logging/redactor'`) and enable it with `logging.redaction.enabled: true`. When loaded and enabled, it is wired into all log methods in the write path.
+`Legion::Logging::Redactor` redacts PII/PHI patterns (SSN, email, phone, MRN, DOB, credit card) plus Vault tokens, JWTs, bearer tokens, `vault://` URIs, `lease://` URIs, and lease IDs from log messages. Redaction is opt-in for text log lines: load the module (for example via `require 'legion/logging/redactor'`) and enable it with `logging.redaction.enabled: true`. When loaded and enabled, it is wired into all log methods in the write path.
+
+Structured exception events are redacted before publishing when the redactor is loaded. This includes event identity fields such as `user`, so email-shaped local usernames are not forwarded raw.
 
 ## Requirements
 

--- a/lib/legion/logging/helper.rb
+++ b/lib/legion/logging/helper.rb
@@ -32,7 +32,6 @@ module Legion
         'middleware' => :middleware
       }.freeze
 
-      EXCEPTION_BACKTRACE_LIMIT = 10
       EXCEPTION_PRIORITY = { warn: 0, error: 5, fatal: 9 }.freeze
       EXCEPTION_COLORS = {
         fatal:   :darkred,
@@ -489,11 +488,7 @@ module Legion
         lines << "  #{context_line}" unless context_line.empty?
 
         bt = exception.backtrace
-        if bt&.any?
-          bt.first(EXCEPTION_BACKTRACE_LIMIT).each { |frame| lines << "  #{frame}" }
-          remaining = bt.length - EXCEPTION_BACKTRACE_LIMIT
-          lines << "  ... #{remaining} more" if remaining.positive?
-        end
+        bt.each { |frame| lines << "  #{frame}" } if bt&.any?
 
         lines.join("\n")
       end

--- a/lib/legion/logging/methods.rb
+++ b/lib/legion/logging/methods.rb
@@ -109,11 +109,8 @@ module Legion
         msg = maybe_redact(msg)
         bt = Array(exception.backtrace)
         if bt.any?
-          limit = defined?(Legion::Logging::Helper::EXCEPTION_BACKTRACE_LIMIT) ? Legion::Logging::Helper::EXCEPTION_BACKTRACE_LIMIT : 10
           lines = ["#{exception.class}: #{msg}"]
-          bt.first(limit).each { |frame| lines << "  #{frame}" }
-          remaining = bt.length - limit
-          lines << "  ... #{remaining} more" if remaining.positive?
+          bt.each { |frame| lines << "  #{frame}" }
           msg = lines.join("\n")
         end
         log.public_send(level, msg) if respond_to?(:log) && log.respond_to?(level)

--- a/lib/legion/logging/version.rb
+++ b/lib/legion/logging/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Logging
-    VERSION = '1.5.1'
+    VERSION = '1.5.2'
   end
 end

--- a/spec/legion/logging/helper_spec.rb
+++ b/spec/legion/logging/helper_spec.rb
@@ -400,11 +400,12 @@ RSpec.describe Legion::Logging::Helper do
       )
     end
 
-    it 'caps backtrace at EXCEPTION_BACKTRACE_LIMIT' do
+    it 'includes the full backtrace' do
       exc = StandardError.new('deep stack')
       exc.set_backtrace(Array.new(25) { |i| "/app/lib/file.rb:#{i}:in `method_#{i}`" })
       subject.handle_exception(exc)
-      expect(underlying_logger).to have_received(:error).with(/\.\.\. 15 more/)
+      expect(underlying_logger).to have_received(:error).with(%r{/app/lib/file\.rb:24})
+      expect(underlying_logger).not_to have_received(:error).with(/\.\.\./)
     end
 
     it 'supports custom log level' do

--- a/spec/legion/logging/log_exception_spec.rb
+++ b/spec/legion/logging/log_exception_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe 'Legion::Logging.log_exception' do
       captured = event[:user]
     }
     Legion::Logging.log_exception(error)
-    expect(captured).to eq(ENV.fetch('USER', nil))
+    expect(captured).to eq(Legion::Logging::Redactor.redact_string(ENV.fetch('USER', nil)))
   end
 
   describe 'backtrace formatting in the sync log line' do
@@ -125,11 +125,11 @@ RSpec.describe 'Legion::Logging.log_exception' do
       Legion::Logging.log_exception(error)
     end
 
-    it 'includes an overflow count line when backtrace exceeds the limit' do
+    it 'includes the full backtrace when many frames are present' do
       deep_error = RuntimeError.new('deep')
-      deep_error.set_backtrace(Array.new(15, 'fake_file.rb:1:in `fake_method`'))
+      deep_error.set_backtrace(Array.new(15) { |i| "fake_file.rb:#{i}:in `fake_method_#{i}`" })
       expect(Legion::Logging.log).to receive(:error).with(
-        satisfy { |msg| msg.include?('... 5 more') }
+        satisfy { |msg| msg.include?('fake_file.rb:14') && !msg.include?('...') }
       ).and_call_original
       Legion::Logging.log_exception(deep_error)
     end


### PR DESCRIPTION
## Summary
- remove the 10-frame cap from synchronous exception log output
- remove overflow-only `... N more` formatting so full backtraces are visible in logs
- update specs for full backtrace output and redacted user event identity
- bump version to 1.5.2 and update changelog

## Verification
- `bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt`
- `bundle exec rubocop -A`