### PR TITLE
Add identity headers to logging events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Legion::Logging Changelog
 
+## [1.5.4] - 2026-05-22
+
+### Added
+- Structured log and exception AMQP writer headers now include `legion_protocol_version`, best-effort `x-legion-version`, and transport-standard `x-legion-identity-*` headers when process identity is resolved.
+- `log_writer` now receives the same `headers:` and `properties:` envelope metadata shape as `exception_writer`.
+
 ## [1.5.3] - 2026-05-13
 
 ### Added

--- a/lib/legion/logging.rb
+++ b/lib/legion/logging.rb
@@ -25,7 +25,7 @@ module Legion
       attr_reader :color
       attr_writer :log_writer, :exception_writer
 
-      DEFAULT_LOG_WRITER = ->(_event, routing_key:) {}
+      DEFAULT_LOG_WRITER = ->(_event, routing_key:, headers: nil, properties: nil) {}
       DEFAULT_EXCEPTION_WRITER = ->(_event, routing_key:, headers:, properties:) {}
 
       def log_writer

--- a/lib/legion/logging/async_writer.rb
+++ b/lib/legion/logging/async_writer.rb
@@ -110,7 +110,9 @@ module Legion
         lex_name = event[:lex] || 'core'
         component = event.dig(:caller, :file).to_s[Legion::Logging::Methods::COMPONENT_REGEX, 1] || 'unknown'
         routing_key = "legion.logging.log.#{level}.#{lex_name}.#{component}"
-        Legion::Logging.log_writer.call(event, routing_key: routing_key)
+        headers    = Legion::Logging.send(:build_log_headers, event, component, level)
+        properties = Legion::Logging.send(:build_log_properties, level)
+        Legion::Logging.log_writer.call(event, routing_key: routing_key, headers: headers, properties: properties)
         Legion::Logging::Hooks.fire(level, entry.message, event) if defined?(Legion::Logging::Hooks)
       rescue StandardError => e
         warn("legion-log-writer writer error: #{e.message}")

--- a/lib/legion/logging/helper.rb
+++ b/lib/legion/logging/helper.rb
@@ -559,19 +559,68 @@ module Legion
 
       def build_exception_headers(event, comp, level)
         headers = {
-          'x-error-fingerprint' => event[:error_fingerprint],
-          'x-exception-class'   => event[:exception_class],
-          'x-handled'           => event[:handled].to_s,
-          'x-gem-name'          => event[:gem_name].to_s,
-          'x-lex-version'       => event[:lex_version].to_s,
-          'x-component-type'    => comp.to_s,
-          'x-level'             => level.to_s
+          'legion_protocol_version' => '2.0',
+          'x-error-fingerprint'     => event[:error_fingerprint],
+          'x-exception-class'       => event[:exception_class],
+          'x-handled'               => event[:handled].to_s,
+          'x-gem-name'              => event[:gem_name].to_s,
+          'x-lex-version'           => event[:lex_version].to_s,
+          'x-component-type'        => comp.to_s,
+          'x-level'                 => level.to_s
         }
+        append_legion_version_header(headers)
         headers['x-task-id'] = event[:task_id].to_s if event[:task_id]
         headers['x-conversation-id'] = event[:conversation_id].to_s if event[:conversation_id]
         headers['x-chain-id'] = event[:chain_id].to_s if event[:chain_id]
         headers['x-user'] = event[:user].to_s if event[:user]
+        append_identity_headers(headers)
         headers
+      end
+
+      def append_identity_headers(headers)
+        return unless defined?(Legion::Identity::Process)
+        return if Legion::Identity::Process.respond_to?(:resolved?) && !Legion::Identity::Process.resolved?
+
+        id = identity_hash
+        append_optional_header(headers, 'x-legion-identity-canonical-name', id[:canonical_name])
+        append_optional_header(headers, 'x-legion-identity-trust', id[:trust])
+        append_optional_header(headers, 'x-legion-identity-id', id[:id])
+        append_optional_header(headers, 'x-legion-identity-kind', id[:kind])
+        append_optional_header(headers, 'x-legion-identity-mode', id[:mode])
+        append_optional_header(headers, 'x-legion-identity-source', id[:source])
+        headers['x-legion-identity-db-principal-id'] = id[:db_principal_id] if id[:db_principal_id]
+        headers['x-legion-identity-db-identity-id'] = id[:db_identity_id] if id[:db_identity_id]
+      rescue StandardError
+        nil
+      end
+
+      def append_optional_header(headers, key, value)
+        return if value.nil?
+        return if value.respond_to?(:empty?) && value.empty?
+
+        headers[key] = value.to_s
+      end
+
+      def append_legion_version_header(headers)
+        append_optional_header(headers, 'x-legion-version', Legion::VERSION) if defined?(Legion::VERSION)
+      end
+
+      def identity_hash
+        process = Legion::Identity::Process
+        return process.identity_hash if process.respond_to?(:identity_hash)
+
+        {
+          canonical_name: identity_value(process, :canonical_name),
+          id:             identity_value(process, :id),
+          kind:           identity_value(process, :kind),
+          mode:           identity_value(process, :mode),
+          source:         identity_value(process, :source),
+          trust:          identity_value(process, :trust)
+        }
+      end
+
+      def identity_value(process, method_name)
+        process.public_send(method_name) if process.respond_to?(method_name)
       end
 
       def build_exception_properties(event, level)

--- a/lib/legion/logging/methods.rb
+++ b/lib/legion/logging/methods.rb
@@ -270,6 +270,48 @@ module Legion
         false
       end
 
+      def build_log_headers(event, component, level)
+        headers = {
+          'legion_protocol_version' => '2.0',
+          'x-component-type'        => component.to_s,
+          'x-level'                 => level.to_s
+        }
+        append_legion_version_header(headers)
+        append_optional_header(headers, 'x-lex', event[:lex])
+        append_optional_header(headers, 'x-node', event[:node])
+        append_identity_headers(headers)
+        headers
+      end
+
+      def build_log_properties(level)
+        {
+          content_type:  'application/json',
+          message_id:    SecureRandom.uuid,
+          timestamp:     Time.now.to_i,
+          app_id:        'legionio',
+          type:          'log_event',
+          priority:      EXCEPTION_PRIORITY[level] || 0,
+          delivery_mode: 2
+        }
+      end
+
+      def append_identity_headers(headers)
+        return unless defined?(Legion::Identity::Process)
+        return if Legion::Identity::Process.respond_to?(:resolved?) && !Legion::Identity::Process.resolved?
+
+        id = identity_hash
+        append_optional_header(headers, 'x-legion-identity-canonical-name', id[:canonical_name])
+        append_optional_header(headers, 'x-legion-identity-trust', id[:trust])
+        append_optional_header(headers, 'x-legion-identity-id', id[:id])
+        append_optional_header(headers, 'x-legion-identity-kind', id[:kind])
+        append_optional_header(headers, 'x-legion-identity-mode', id[:mode])
+        append_optional_header(headers, 'x-legion-identity-source', id[:source])
+        headers['x-legion-identity-db-principal-id'] = id[:db_principal_id] if id[:db_principal_id]
+        headers['x-legion-identity-db-identity-id'] = id[:db_identity_id] if id[:db_identity_id]
+      rescue StandardError
+        nil
+      end
+
       def publish_exception_event(event, level)
         lex_name = event[:lex] || 'core'
         comp     = event[:component_type] || :unknown
@@ -281,17 +323,20 @@ module Legion
 
       def build_exception_headers(event, comp, level)
         headers = {
-          'x-error-fingerprint' => event[:error_fingerprint],
-          'x-exception-class'   => event[:exception_class],
-          'x-handled'           => event[:handled].to_s,
-          'x-gem-name'          => event[:gem_name].to_s,
-          'x-lex-version'       => event[:lex_version].to_s,
-          'x-component-type'    => comp.to_s,
-          'x-level'             => level.to_s
+          'legion_protocol_version' => '2.0',
+          'x-error-fingerprint'     => event[:error_fingerprint],
+          'x-exception-class'       => event[:exception_class],
+          'x-handled'               => event[:handled].to_s,
+          'x-gem-name'              => event[:gem_name].to_s,
+          'x-lex-version'           => event[:lex_version].to_s,
+          'x-component-type'        => comp.to_s,
+          'x-level'                 => level.to_s
         }
+        append_legion_version_header(headers)
         append_optional_header(headers, 'x-task-id', event[:task_id])
         append_optional_header(headers, 'x-conversation-id', event[:conversation_id])
         append_optional_header(headers, 'x-user', event[:user])
+        append_identity_headers(headers)
         headers
       end
 
@@ -300,6 +345,28 @@ module Legion
         return if value.respond_to?(:empty?) && value.empty?
 
         headers[key] = value.to_s
+      end
+
+      def append_legion_version_header(headers)
+        append_optional_header(headers, 'x-legion-version', Legion::VERSION) if defined?(Legion::VERSION)
+      end
+
+      def identity_hash
+        process = Legion::Identity::Process
+        return process.identity_hash if process.respond_to?(:identity_hash)
+
+        {
+          canonical_name: identity_value(process, :canonical_name),
+          id:             identity_value(process, :id),
+          kind:           identity_value(process, :kind),
+          mode:           identity_value(process, :mode),
+          source:         identity_value(process, :source),
+          trust:          identity_value(process, :trust)
+        }
+      end
+
+      def identity_value(process, method_name)
+        process.public_send(method_name) if process.respond_to?(method_name)
       end
 
       def build_exception_properties(event, level)
@@ -347,7 +414,9 @@ module Legion
         lex_name = event[:lex] || 'core'
         component = event.dig(:caller, :file).to_s[COMPONENT_REGEX, 1] || 'unknown'
         routing_key = "legion.logging.log.#{level}.#{lex_name}.#{component}"
-        Legion::Logging.log_writer.call(event, routing_key: routing_key)
+        headers    = build_log_headers(event, component, level)
+        properties = build_log_properties(level)
+        Legion::Logging.log_writer.call(event, routing_key: routing_key, headers: headers, properties: properties)
         Legion::Logging::Hooks.fire(level, message, event) if defined?(Legion::Logging::Hooks)
       rescue StandardError => e
         rk = defined?(routing_key) ? routing_key : 'unknown'

--- a/lib/legion/logging/version.rb
+++ b/lib/legion/logging/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Logging
-    VERSION = '1.5.3'
+    VERSION = '1.5.4'
   end
 end

--- a/spec/legion/logging/async_writer_spec.rb
+++ b/spec/legion/logging/async_writer_spec.rb
@@ -171,8 +171,8 @@ RSpec.describe Legion::Logging::AsyncWriter do
 
     it 'calls log_writer when writer_context is present' do
       captured = nil
-      Legion::Logging.log_writer = lambda { |event, routing_key:|
-        captured = { event: event, routing_key: routing_key }
+      Legion::Logging.log_writer = lambda { |event, routing_key:, headers: nil, properties: nil|
+        captured = { event: event, routing_key: routing_key, headers: headers, properties: properties }
       }
 
       event = { level: :error, message: 'writer test', lex: 'core' }

--- a/spec/legion/logging/helper_spec.rb
+++ b/spec/legion/logging/helper_spec.rb
@@ -388,6 +388,20 @@ RSpec.describe Legion::Logging::Helper do
       writer = instance_double(Proc)
       allow(writer).to receive(:call)
       allow(Legion::Logging).to receive(:exception_writer).and_return(writer)
+      stub_const('Legion::VERSION', '1.9.99')
+      stub_const('Legion::Identity::Process', Class.new do
+        def self.resolved? = true
+
+        def self.identity_hash
+          {
+            canonical_name: 'agent.local',
+            id:             'ident-123',
+            kind:           'process',
+            mode:           'service',
+            source:         'lex-identity-system'
+          }
+        end
+      end)
 
       exc = StandardError.new('publish test')
       subject.handle_exception(exc)
@@ -395,7 +409,13 @@ RSpec.describe Legion::Logging::Helper do
       expect(writer).to have_received(:call).with(
         hash_including(exception_class: 'StandardError'),
         routing_key: /legion\.logging\.exception\.error/,
-        headers:     hash_including('x-exception-class' => 'StandardError'),
+        headers:     hash_including(
+          'legion_protocol_version'          => '2.0',
+          'x-legion-version'                 => '1.9.99',
+          'x-exception-class'                => 'StandardError',
+          'x-legion-identity-canonical-name' => 'agent.local',
+          'x-legion-identity-id'             => 'ident-123'
+        ),
         properties:  hash_including(type: 'exception_event')
       )
     end

--- a/spec/legion/logging/log_exception_spec.rb
+++ b/spec/legion/logging/log_exception_spec.rb
@@ -51,6 +51,46 @@ RSpec.describe 'Legion::Logging.log_exception' do
     expect(captured['x-gem-name']).to eq('lex-eval')
   end
 
+  it 'includes protocol, Legion version, and identity headers' do
+    stub_const('Legion::VERSION', '1.9.99')
+    stub_const('Legion::Identity::Process', Class.new do
+      def self.resolved? = true
+
+      def self.identity_hash
+        {
+          canonical_name:  'agent.local',
+          trust:           'local',
+          id:              'ident-123',
+          kind:            'process',
+          mode:            'service',
+          source:          'lex-identity-system',
+          db_principal_id: 42,
+          db_identity_id:  99
+        }
+      end
+    end)
+
+    captured = nil
+    Legion::Logging.exception_writer = lambda { |_event, headers:, **|
+      captured = headers
+    }
+
+    Legion::Logging.log_exception(error)
+
+    expect(captured).to include(
+      'legion_protocol_version'           => '2.0',
+      'x-legion-version'                  => '1.9.99',
+      'x-legion-identity-canonical-name'  => 'agent.local',
+      'x-legion-identity-trust'           => 'local',
+      'x-legion-identity-id'              => 'ident-123',
+      'x-legion-identity-kind'            => 'process',
+      'x-legion-identity-mode'            => 'service',
+      'x-legion-identity-source'          => 'lex-identity-system',
+      'x-legion-identity-db-principal-id' => 42,
+      'x-legion-identity-db-identity-id'  => 99
+    )
+  end
+
   it 'includes AMQP properties' do
     captured = nil
     Legion::Logging.exception_writer = lambda { |_event, properties:, **|

--- a/spec/legion/logging/writers_spec.rb
+++ b/spec/legion/logging/writers_spec.rb
@@ -15,15 +15,51 @@ RSpec.describe 'Legion::Logging writers' do
 
     it 'can be set to a custom writer' do
       captured = []
-      Legion::Logging.log_writer = ->(event, routing_key:) { captured << { event: event, routing_key: routing_key } }
-      Legion::Logging.log_writer.call({ level: :error }, routing_key: 'test')
+      Legion::Logging.log_writer = ->(event, routing_key:, headers: nil, properties: nil) { captured << { event: event, routing_key: routing_key, headers: headers, properties: properties } }
+      Legion::Logging.log_writer.call({ level: :error }, routing_key: 'test', headers: { 'x-level' => 'error' }, properties: { app_id: 'legionio' })
       expect(captured.size).to eq(1)
+      expect(captured.first[:headers]).to eq({ 'x-level' => 'error' })
     end
 
     it 'resets to no-op when set to nil' do
-      Legion::Logging.log_writer = ->(_e, routing_key:) {}
+      Legion::Logging.log_writer = ->(_e, routing_key:, headers: nil, properties: nil) {}
       Legion::Logging.log_writer = nil
       expect { Legion::Logging.log_writer.call({}, routing_key: 'x') }.not_to raise_error
+    end
+
+    it 'builds log headers with protocol, Legion version, and identity headers' do
+      stub_const('Legion::VERSION', '1.9.99')
+      stub_const('Legion::Identity::Process', Class.new do
+        def self.resolved? = true
+
+        def self.identity_hash
+          {
+            canonical_name:  'agent.local',
+            trust:           'local',
+            id:              'ident-123',
+            kind:            'process',
+            mode:            'service',
+            source:          'lex-identity-system',
+            db_principal_id: 42,
+            db_identity_id:  99
+          }
+        end
+      end)
+
+      headers = Legion::Logging.send(:build_log_headers, { lex: 'agentic-memory', node: 'node-1' }, 'helper', :error)
+
+      expect(headers).to include(
+        'legion_protocol_version'           => '2.0',
+        'x-legion-version'                  => '1.9.99',
+        'x-legion-identity-canonical-name'  => 'agent.local',
+        'x-legion-identity-trust'           => 'local',
+        'x-legion-identity-id'              => 'ident-123',
+        'x-legion-identity-kind'            => 'process',
+        'x-legion-identity-mode'            => 'service',
+        'x-legion-identity-source'          => 'lex-identity-system',
+        'x-legion-identity-db-principal-id' => 42,
+        'x-legion-identity-db-identity-id'  => 99
+      )
     end
   end
 


### PR DESCRIPTION
## Summary
- Adds protocol, Legion version, and transport-standard x-legion-identity-* headers to structured log and exception AMQP events.
- Passes log_writer headers/properties through the same envelope contract already used by exception_writer.
- Bumps legion-logging to 1.5.4 and updates changelog/spec coverage.

## Verification
- bundle exec rspec --format json --out tmp/rspec_results.json --format progress --out tmp/rspec_progress.txt
- bundle exec rubocop -A