### PR TITLE
route all logging through async writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Legion::Logging Changelog
 
+## [1.5.5] - 2026-05-27
+
+### Fixed
+- `emit_tagged` (used by all Legion::Logging::Helper consumers) now routes through the async writer instead of doing synchronous IO#write — eliminates IO mutex contention across all consumer threads
+- `fatal` level now routes through async writer consistently with all other levels
+- `log_exception` now writes through async writer instead of direct `log.public_send`
+- `Legion::Logging::Logger` defaults to `async: true`, ensuring all per-extension logger instances use non-blocking writes
+
 ## [1.5.4] - 2026-05-22
 
 ### Added

--- a/lib/legion/logging/logger.rb
+++ b/lib/legion/logging/logger.rb
@@ -11,7 +11,7 @@ module Legion
       include Legion::Logging::Methods
       include Legion::Logging::Builder
 
-      def initialize(level: 'info', log_file: nil, log_stdout: nil, lex: nil, trace: false, extended: false, trace_size: 4, format: :text, async: false, **opts)
+      def initialize(level: 'info', log_file: nil, log_stdout: nil, lex: nil, trace: false, extended: false, trace_size: 4, format: :text, async: true, **opts)
         @lex = lex
         set_log(logfile: log_file, log_stdout: log_stdout)
         log_level(level)

--- a/lib/legion/logging/methods.rb
+++ b/lib/legion/logging/methods.rb
@@ -66,11 +66,9 @@ module Legion
         return unless log.level < 5
 
         message = yield if message.nil? && block_given?
-        message = maybe_redact(message)
-        raw = message
-        message = Rainbow(message).darkred if @color
-        log.fatal(message)
-        fire_log_writer(:fatal, raw)
+        raw = maybe_redact(message)
+        formatted = format_message_for_level(:fatal, raw)
+        write_async_or_sync(:fatal, formatted, raw, writer_context: build_writer_context(:fatal, raw))
       end
 
       def unknown(message = nil)
@@ -89,8 +87,20 @@ module Legion
         formatted = format_message_for_level(level, raw)
 
         with_tagged_context(segments, method_ctx) do
-          write_forced(level, formatted)
-          fire_log_writer(level, raw) if %i[warn error fatal].include?(level)
+          ctx = %i[warn error fatal].include?(level) ? build_writer_context(level, raw) : nil
+          writer = @async_writer
+          caller_trace = capture_runner_trace_for_async
+          if writer&.alive?
+            writer.push(AsyncWriter::LogEntry.new(
+                          level: level, message: formatted, writer_context: ctx,
+                          segments: Thread.current[:legion_log_segments],
+                          method_ctx: Thread.current[:legion_log_method],
+                          caller_trace: caller_trace
+                        ))
+          else
+            with_caller_trace(caller_trace) { write_forced(level, formatted) }
+            fire_log_writer(level, raw) if ctx
+          end
         end
       end
 
@@ -104,11 +114,12 @@ module Legion
                         source_code_uri: nil, handled: false, payload_summary: nil,
                         task_id: nil, backtrace_limit: nil, **extra)
         level = level.to_sym if level.respond_to?(:to_sym)
-        # 1. Log human-readable line + backtrace to stdout/file (bypass writer callbacks)
+        # 1. Log human-readable line + backtrace via async writer
         msg = exception.respond_to?(:message) ? exception.message : exception.to_s
         msg = maybe_redact(msg)
         msg = build_exception_log_message(exception, msg, backtrace_limit)
-        log.public_send(level, msg) if respond_to?(:log) && log.respond_to?(level)
+        formatted = format_message_for_level(level, msg)
+        write_async_or_sync(level, formatted, msg)
 
         # 2. Build rich exception event
         event = Legion::Logging::EventBuilder.build_exception(

--- a/lib/legion/logging/version.rb
+++ b/lib/legion/logging/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Logging
-    VERSION = '1.5.4'
+    VERSION = '1.5.5'
   end
 end

--- a/spec/legion/logging/async_writer_spec.rb
+++ b/spec/legion/logging/async_writer_spec.rb
@@ -210,9 +210,9 @@ RSpec.describe 'Legion::Logging::Logger instance async' do
     logger.stop_async_writer
   end
 
-  it 'defaults to sync when async not specified' do
+  it 'defaults to async when async not specified' do
     logger = Legion::Logging::Logger.new(level: 'info')
-    expect(logger.async?).to be false
+    expect(logger.async?).to be true
   end
 end
 
@@ -252,10 +252,10 @@ RSpec.describe 'async routing through Methods' do
     Legion::Logging.warn('async warn')
   end
 
-  it 'does NOT route fatal through async writer' do
+  it 'routes fatal through async writer' do
     writer = Legion::Logging.instance_variable_get(:@async_writer)
-    expect(writer).not_to receive(:push)
-    Legion::Logging.fatal('sync fatal')
+    expect(writer).to receive(:push).and_call_original
+    Legion::Logging.fatal('async fatal')
   end
 
   it 'falls back to sync when async is disabled' do

--- a/spec/legion/logging_spec.rb
+++ b/spec/legion/logging_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Legion::Logging do
   end
 
   before do
-    @logger = Legion::Logging::Logger.new(level: 'debug', lex: 'foobar', trace: true, extended: true)
+    @logger = Legion::Logging::Logger.new(level: 'debug', lex: 'foobar', trace: true, extended: true, async: false)
   end
   it 'can log with lex name' do
     expect { @logger.fatal('message') }.to output(/message/).to_stdout_from_any_process


### PR DESCRIPTION
## Summary
- `emit_tagged` (used by all `Legion::Logging::Helper` consumers) now routes through the async writer instead of synchronous `IO#write`
- `fatal` level and `log_exception` now consistently use async path
- `Legion::Logging::Logger` defaults to `async: true`

## Problem
Every extension using `Legion::Logging::Helper` (all of them) was doing synchronous IO writes through a shared Monitor lock. With 89 threads, this serialized all consumer message processing on a single IO mutex — the #1 throughput bottleneck alongside PG round-trips.

## Impact
- Eliminates IO mutex contention across all consumer threads
- Combined with other fixes: lex.register throughput 2.0 msg/s → 196 msg/s

## Test plan
- [x] 360 specs pass, 0 failures
- [x] rubocop clean (0 offenses)
- [x] Verified live: async writer drains queue, no back-pressure